### PR TITLE
Update node.vue

### DIFF
--- a/uni_modules/uview-plus/components/u-parse/node/node.vue
+++ b/uni_modules/uview-plus/components/u-parse/node/node.vue
@@ -125,8 +125,9 @@ export default {
     opts: Array
   },
   components: {
-
-    node
+	// #ifdef VUE2
+	node
+	// #endif
   },
   mounted() {
     for (this.root = this.$parent; this.root.$options.name != 'mp-html'; this.root = this.root.$parent);


### PR DESCRIPTION
解决u-parse修复后依然存在Cannot access 'node' before initialization的报警提示的问题