### PR TITLE
Update u-number-box.vue

### DIFF
--- a/uni_modules/uview-plus/components/u-number-box/u-number-box.vue
+++ b/uni_modules/uview-plus/components/u-number-box/u-number-box.vue
@@ -200,7 +200,7 @@
 			this.init()
 		},
 		// #ifdef VUE3
-		emits: ['update:modelValue', 'focus', 'blur', 'overlimit'],
+		emits: ['update:modelValue', 'focus', 'blur', 'overlimit', 'change', 'plus', 'minus'],
 		// #endif
 		methods: {
 			init() {


### PR DESCRIPTION
修复在Vue3下，未在emits中定义change、plus、minus事件所引起的控制台警告提示的问题