### PR TITLE
修复富文本事件名称大小写问题

### DIFF
--- a/src/uni_modules/uview-plus/components/u-parse/node/node.vue
+++ b/src/uni_modules/uview-plus/components/u-parse/node/node.vue
@@ -227,7 +227,7 @@ export default {
       // #ifdef H5 || APP-PLUS
       node.attrs.src = node.attrs.src || node.attrs['data-src']
       // #endif
-      this.root.$emit('imgtap', node.attrs)
+      this.root.$emit('imgTap', node.attrs)
       // 自动预览图片
       if (this.root.previewImg) {
         uni.previewImage({
@@ -321,7 +321,7 @@ export default {
       const node = e.currentTarget ? this.childs[e.currentTarget.dataset.i] : {}
       const attrs = node.attrs || e
       const href = attrs.href
-      this.root.$emit('linktap', Object.assign({
+      this.root.$emit('linkTap', Object.assign({
         innerText: this.root.getText(node.children || []) // 链接内的文本内容
       }, attrs))
       if (href) {

--- a/src/uni_modules/uview-plus/components/u-parse/parser.js
+++ b/src/uni_modules/uview-plus/components/u-parse/parser.js
@@ -336,7 +336,7 @@ Parser.prototype.onAttrName = function (name) {
       // data-src 自动转为 src
       this.attrName = 'src'
     } else if (this.tagName === 'img' || this.tagName === 'a') {
-      // a 和 img 标签保留 data- 的属性，可以在 imgtap 和 linktap 事件中使用
+      // a 和 img 标签保留 data- 的属性，可以在 imgTap 和 linkTap 事件中使用
       this.attrName = name
     } else {
       // 剩余的移除以减小大小

--- a/src/uni_modules/uview-plus/components/u-parse/u-parse.vue
+++ b/src/uni_modules/uview-plus/components/u-parse/u-parse.vue
@@ -32,8 +32,8 @@
  * @property {Boolean | Number} use-anchor 是否使用锚点链接
  * @event {Function} load dom 结构加载完毕时触发
  * @event {Function} ready 所有图片加载完毕时触发
- * @event {Function} imgtap 图片被点击时触发
- * @event {Function} linktap 链接被点击时触发
+ * @event {Function} imgTap 图片被点击时触发
+ * @event {Function} linkTap 链接被点击时触发
  * @event {Function} play 音视频播放时触发
  * @event {Function} error 媒体加载出错时触发
  */
@@ -410,7 +410,7 @@ export default {
 					break
 				// 图片点击
 				case 'onImgTap':
-					this.$emit('imgtTap', message.attrs)
+					this.$emit('imgTap', message.attrs)
 					if (this.previewImg) {
 						uni.previewImage({
 							current: parseInt(message.attrs.i),


### PR DESCRIPTION
代码和注释都改成了文档规定的方法名