### PR TITLE
fix u-search showAction prop not work

### DIFF
--- a/src/uni_modules/uview-plus/components/u-search/u-search.vue
+++ b/src/uni_modules/uview-plus/components/u-search/u-search.vue
@@ -63,6 +63,7 @@
 			</view>
 		</view>
 		<text
+			v-if="showAction"
 		    :style="[actionStyle]"
 		    class="u-search__action"
 		    :class="[(showActionBtn || show) && 'u-search__action--active']"


### PR DESCRIPTION
showAction 是否显示右侧控件(右侧的"搜索"按钮)没实现