### PR TITLE
修复u-cell title被value压缩的问题

### DIFF
--- a/src/uni_modules/uview-plus/components/u-cell/u-cell.vue
+++ b/src/uni_modules/uview-plus/components/u-cell/u-cell.vue
@@ -145,7 +145,7 @@
 			&__content {
 				@include flex(row);
 				align-items: center;
-				flex: 1;
+				flex: 1 0 1;
 			}
 
 			&--large {
@@ -207,10 +207,10 @@
 
 		&__value {
 			text-align: right;
+			margin-left: auto;
 			font-size: $u-cell-value-font-size;
 			line-height: $u-cell-line-height;
 			color: $u-cell-value-color;
-
 			&--large {
 				font-size: $u-cell-value-font-size-large;
 			}


### PR DESCRIPTION
u-cell在微信小程序中会出现title被压缩value压缩的情况
![image](https://github.com/ijry/uview-plus/assets/104250107/e8aacef1-b12a-4880-a5d5-aa7e45976ca2)
修改后正常 其他部分也正常
![image](https://github.com/ijry/uview-plus/assets/104250107/5a7cbe37-ae97-4211-bf71-6bb3df63356b)
