### PR TITLE
修复up-calendar日历控件在不显示确定按钮的情况下(show-confirm 绑定假值),点击弹窗弹起展示日历时会自动触发日历的确…

### DIFF
--- a/src/uni_modules/uview-plus/components/u-calendar/month.vue
+++ b/src/uni_modules/uview-plus/components/u-calendar/month.vue
@@ -450,7 +450,7 @@
 			},
 			setSelected(selected, event = true) {
 				this.selected = selected
-				event && this.$emit('monthSelected', this.selected)
+				event && this.$emit('monthSelected', this.selected,'tap')
 			}
 		}
 	}

--- a/src/uni_modules/uview-plus/components/u-calendar/u-calendar.vue
+++ b/src/uni_modules/uview-plus/components/u-calendar/u-calendar.vue
@@ -199,7 +199,7 @@ export default {
 			this.innerFormatter = e
 		},
 		// month组件内部选择日期后，通过事件通知给父组件
-		monthSelected(e) {
+		monthSelected(e,scene ='init') {
 			this.selected = e
 			if (!this.showConfirm) {
 				// 在不需要确认按钮的情况下，如果为单选，或者范围多选且已选长度大于2，则直接进行返还
@@ -208,7 +208,12 @@ export default {
 					this.mode === 'single' ||
 					(this.mode === 'range' && this.selected.length >= 2)
 				) {
-					this.$emit('confirm', this.selected)
+				   if( scene === 'init'){
+					 return
+				   }
+				   if( scene === 'tap') {
+					 this.$emit('confirm', this.selected)
+				   }
 				}
 			}
 		},


### PR DESCRIPTION
修复up-calendar日历控件在不显示确定按钮的情况下(show-confirm 绑定假值),点击弹窗弹起展示日历时会自动触发日历的确定时间回调。
![image](https://github.com/ijry/uview-plus/assets/31398749/6363e29c-bc5e-4a0f-b0df-2c2ec1d0fb7f)
