### PR TITLE
修复在支付宝小程序上因为使用text标签，上面的类名使用的样式不生效，导致所有选择的项目显示到了一行的问题

### DIFF
--- a/src/uni_modules/uview-plus/components/u-picker/u-picker.vue
+++ b/src/uni_modules/uview-plus/components/u-picker/u-picker.vue
@@ -30,7 +30,7 @@
 					:key="index"
 					class="u-picker__view__column"
 				>
-					<text
+					<view
 						v-if="$u.test.array(item)"
 						class="u-picker__view__column__item u-line-1"
 						v-for="(item1, index1) in item"
@@ -40,7 +40,7 @@
 							lineHeight: $u.addUnit(itemHeight),
 							fontWeight: index1 === innerIndex[index] ? 'bold' : 'normal'
 						}"
-					>{{ getItemText(item1) }}</text>
+					>{{ getItemText(item1) }}</view>
 				</picker-view-column>
 			</picker-view>
 			<view


### PR DESCRIPTION
修复在支付宝小程序上因为使用text标签，上面的类名使用的样式不生效，导致所有选择的项目显示到了一行的问题