### PR TITLE
修复支付宝小程序下textarea显示两个字数统计的问题，支付宝小程序textarea show-count属性默认为true，默认就是带…

### DIFF
--- a/src/uni_modules/uview-plus/components/u-textarea/u-textarea.vue
+++ b/src/uni_modules/uview-plus/components/u-textarea/u-textarea.vue
@@ -29,6 +29,7 @@
             @confirm="onConfirm"
             @keyboardheightchange="onKeyboardheightchange"
         ></textarea>
+		<!-- #ifndef MP-ALIPAY -->
         <text
             class="u-textarea__count"
             :style="{
@@ -37,6 +38,7 @@
             v-if="count"
             >{{ innerValue.length }}/{{ maxlength }}</text
         >
+		<!-- #endif -->
     </view>
 </template>
 


### PR DESCRIPTION
…着字数统计的。

修复支付宝小程序下textarea显示两个字数统计的问题，支付宝小程序textarea show-count属性默认为true，默认就是带着字数统计的。