### PR TITLE
fix: 修复自定义图标无效问题

### DIFF
--- a/src/uni_modules/uview-plus/components/u-icon/u-icon.vue
+++ b/src/uni_modules/uview-plus/components/u-icon/u-icon.vue
@@ -92,12 +92,13 @@
 			uClasses() {
 				let classes = []
 				classes.push(this.customPrefix + '-' + this.name)
-				// // uView的自定义图标类名为u-iconfont
-				// if (this.customPrefix == 'uicon') {
-				// 	classes.push('u-iconfont')
-				// } else {
-				// 	classes.push(this.customPrefix)
-				// }
+				// uView的自定义图标类名为u-iconfont
+				if (this.customPrefix == 'uicon') {
+					classes.push('u-iconfont')
+				} else {
+					// 不能缺少这一步，否则自定义图标会无效
+					classes.push(this.customPrefix)
+				}
 				// 主题色，通过类配置
 				if (this.color && uni.$u.config.type.includes(this.color)) classes.push('u-icon__icon--' + this.color)
 				// 阿里，头条，百度小程序通过数组绑定类名时，无法直接使用[a, b, c]的形式，否则无法识别
@@ -134,6 +135,8 @@
 			},
 			// 通过图标名，查找对应的图标
 			icon() {
+				// 使用自定义图标的时候页面上会把name属性也展示出来，所以在这里处理一下
+				if (this.customPrefix !== "uicon") return "";
 				// 如果内置的图标中找不到对应的图标，就直接返回name值，因为用户可能传入的是unicode代码
 				return icons['uicon-' + this.name] || this.name
 			}


### PR DESCRIPTION
> **背景**：使用过程中发现按照官网自定义图标的步骤配置后，页面中显示异常，排查后发现是因为没有加上自定义图标的字体样式导致的，所以对这一问题进行修复

预期表现
![image](https://github.com/ijry/uview-plus/assets/64246444/c659021e-d881-45ca-ba6d-23ef00b66511)

实际表现
![image](https://github.com/ijry/uview-plus/assets/64246444/f8440282-7f5f-47bf-a2f6-d7cf869df5a6)

代码
![image](https://github.com/ijry/uview-plus/assets/64246444/3f6e4639-55f6-420f-8562-512690c30dd0)



- [ ] 源码里已经有添加字体样式的逻辑，不知道当时为什么把把这段代码注释掉了