### PR TITLE
修复tabs中，当前激活样式的undefined bug

### DIFF
--- a/src/uni_modules/uview-plus/components/u-tabs/u-tabs.vue
+++ b/src/uni_modules/uview-plus/components/u-tabs/u-tabs.vue
@@ -142,9 +142,7 @@
 				return index => {
 					const style = {}
 					// 取当期是否激活的样式
-					const customeStyle = index === this.innerCurrent ? addStyle(this.activeStyle) : uni.$u
-						.addStyle(
-							this.inactiveStyle)
+					const customeStyle = index === this.innerCurrent ? addStyle(this.activeStyle) : addStyle(this.inactiveStyle)
 					// 如果当前菜单被禁用，则加上对应颜色，需要在此做处理，是因为nvue下，无法在style样式中通过!import覆盖标签的内联样式
 					if (this.list[index].disabled) {
 						style.color = '#c8c9cc'


### PR DESCRIPTION
修复tabs组件中，激活当前样式部分的bug
![image](https://github.com/ijry/uview-plus/assets/38091003/a4fe6760-abc7-446c-9a49-a76344e58685)
![image](https://github.com/ijry/uview-plus/assets/38091003/766daf2c-bd5a-4a1f-ace6-bdb4911b2e74)
错误原因:：uin.$u.addStyle方法未定义。
解决：直接调用已引入的addStyle方法。
![image](https://github.com/ijry/uview-plus/assets/38091003/e73c86f6-c864-4007-a117-1ff72ad4bd86)
