### PR TITLE
修复：ActionSheet 操作菜单cancelText属性为空DOM节点还存在并且可以点击问题

### DIFF
--- a/src/uni_modules/uview-plus/components/u-action-sheet/u-action-sheet.vue
+++ b/src/uni_modules/uview-plus/components/u-action-sheet/u-action-sheet.vue
@@ -93,11 +93,10 @@
 			    v-if="cancelText"
 			></u-gap>
 			<view class="u-action-sheet__item-wrap__item u-action-sheet__cancel"
-				hover-class="u-action-sheet--hover" @tap="cancel">
+				hover-class="u-action-sheet--hover" @tap="cancel" v-if="cancelText">
 				<text
 				    @touchmove.stop.prevent
 				    :hover-stay-time="150"
-				    v-if="cancelText"
 				    class="u-action-sheet__cancel-text"
 				>{{cancelText}}</text>
 			</view>


### PR DESCRIPTION
[https://github.com/ijry/uview-plus/issues/426](url)
![image](https://github.com/user-attachments/assets/aa551b4d-79f1-4fa3-a7f5-b8e6c860a009)
![image](https://github.com/user-attachments/assets/0c37f352-c196-41d0-93f9-00e345e0b340)
