### PR TITLE
u-datetime-picker + input 模式下，弹窗后input框仍可以编辑

### DIFF
--- a/src/uni_modules/uview-plus/components/u-datetime-picker/u-datetime-picker.vue
+++ b/src/uni_modules/uview-plus/components/u-datetime-picker/u-datetime-picker.vue
@@ -2,6 +2,7 @@
     <view v-if="hasInput" class="u-datetime-picker">
         <u-input
             :placeholder="placeholder"
+			:readonly="!!showByClickInput"
             border="surround"
             v-model="inputValue"
             @click="showByClickInput = !showByClickInput"


### PR DESCRIPTION
场景：
windows h5开发，使用带input的u-datetime-pick组件

问题：
弹出选择日期后，input框仍可以编辑，可能会导致输入框和值和日期选择的值不一致
![date-time-picker](https://github.com/user-attachments/assets/d6cfe83a-de69-489a-a42c-de6a2e22bff9)


预期：
弹出选择日期后，input自动变为只读状态
