### PR TITLE
fix:修复swiper中title换行后多余的内容未被遮挡问题

### DIFF
--- a/src/uni_modules/uview-plus/components/u-swiper/u-swiper.vue
+++ b/src/uni_modules/uview-plus/components/u-swiper/u-swiper.vue
@@ -68,10 +68,9 @@
 						controls
 						@tap="clickHandler(index)"
 					></video>
-					<text
-						v-if="showTitle && testObject(item) && item.title && testImage(getSource(item))"
-						class="u-swiper__wrapper__item__wrapper__title u-line-1"
-					>{{ item.title }}</text>
+					<view v-if="showTitle && testObject(item) && item.title && testImage(getSource(item))" class="u-swiper__wrapper__item__wrapper__title">
+						<text class="u-line-1">{{ item.title }}</text>
+					</view>
 				</view>
 			</swiper-item>
 		</swiper>


### PR DESCRIPTION
修复swiper中title换行后多余的内容未被遮挡问题