### PR TITLE
修复up-datetime-picker组件使用的时候Property "toolbarRightSlot" was accessed during render but is not defined on instance.的提示

### DIFF
--- a/src/uni_modules/uview-plus/components/up-datetime-picker/props.js
+++ b/src/uni_modules/uview-plus/components/up-datetime-picker/props.js
@@ -30,6 +30,11 @@ export const props = defineMixin({
             type: Boolean,
             default: () => defProps.datetimePicker.showToolbar
         },
+		// 工具栏右侧内容
+		toolbarRightSlot:{
+			type:Boolean,
+			default: () => defProps.datetimePicker.toolbarRightSlot
+		},
         // #ifdef VUE2
         // 绑定值
         value: {


### PR DESCRIPTION
修复up-datetime-picker组件使用的时候Property "toolbarRightSlot" was accessed during render but is not defined on instance.的提示