### PR TITLE
Update up-list.vue

### DIFF
--- a/src/uni_modules/uview-plus/components/up-list/up-list.vue
+++ b/src/uni_modules/uview-plus/components/up-list/up-list.vue
@@ -129,7 +129,7 @@
 				scrollTop = e.detail.scrollTop
 				// #endif
 				this.innerScrollTop = scrollTop
-				this.$emit('scroll', Math.abs(scrollTop))
+				this.$emit('scroll', scrollTop)
 			},
 			scrollIntoViewById(id) {
 				// #ifdef APP-NVUE


### PR DESCRIPTION
list 滑动 偏移量不一样取绝对值，会导致iOS下拉偏移量计算错误