### PR TITLE
feat: 修改了libs/function下的test.js和test.uts文件中的date方法的校验为类型+正则

### DIFF
--- a/src/uni_modules/uview-plus/libs/function/test.js
+++ b/src/uni_modules/uview-plus/libs/function/test.js
@@ -2,60 +2,94 @@
  * 验证电子邮箱格式
  */
 export function email(value) {
-    return /^\w+((-\w+)|(\.\w+))*\@[A-Za-z0-9]+((\.|-)[A-Za-z0-9]+)*\.[A-Za-z0-9]+$/.test(value)
+    return /^\w+((-\w+)|(\.\w+))*\@[A-Za-z0-9]+((\.|-)[A-Za-z0-9]+)*\.[A-Za-z0-9]+$/.test(
+        value
+    );
 }
 
 /**
  * 验证手机格式
  */
 export function mobile(value) {
-    return /^1[23456789]\d{9}$/.test(value)
+    return /^1[23456789]\d{9}$/.test(value);
 }
 
 /**
  * 验证URL格式
  */
 export function url(value) {
-    return /^((https|http|ftp|rtsp|mms):\/\/)(([0-9a-zA-Z_!~*'().&=+$%-]+: )?[0-9a-zA-Z_!~*'().&=+$%-]+@)?(([0-9]{1,3}.){3}[0-9]{1,3}|([0-9a-zA-Z_!~*'()-]+.)*([0-9a-zA-Z][0-9a-zA-Z-]{0,61})?[0-9a-zA-Z].[a-zA-Z]{2,6})(:[0-9]{1,4})?((\/?)|(\/[0-9a-zA-Z_!~*'().;?:@&=+$,%#-]+)+\/?)$/
-        .test(value)
+    return /^((https|http|ftp|rtsp|mms):\/\/)(([0-9a-zA-Z_!~*'().&=+$%-]+: )?[0-9a-zA-Z_!~*'().&=+$%-]+@)?(([0-9]{1,3}.){3}[0-9]{1,3}|([0-9a-zA-Z_!~*'()-]+.)*([0-9a-zA-Z][0-9a-zA-Z-]{0,61})?[0-9a-zA-Z].[a-zA-Z]{2,6})(:[0-9]{1,4})?((\/?)|(\/[0-9a-zA-Z_!~*'().;?:@&=+$,%#-]+)+\/?)$/.test(
+        value
+    );
 }
 
 /**
  * 验证日期格式
+ * @param {number | string} value yyyy-mm-dd hh:mm:ss 或 时间戳
  */
 export function date(value) {
-    if (!value) return false
-    // 判断是否数值或者字符串数值(意味着为时间戳)，转为数值，否则new Date无法识别字符串时间戳
-    if (number(value)) value = +value
-    return !/Invalid|NaN/.test(new Date(value).toString())
+    if (!value) return false;
+    // number类型，判断是否是时间戳
+    if (typeof value === "number") {
+        // len === 10 秒级时间戳 len === 13 毫秒级时间戳
+        if (value.toString().length !== 10 && value.toString().length !== 13) {
+            return false;
+        }
+        return !isNaN(new Date(value).getTime());
+    }
+    if (typeof value === "string") {
+        // 是否为string类型时间戳
+        const numV = Number(value);
+        if (!isNaN(numV)) {
+            if (numV.toString().length === 10 || numV.toString().length === 13) {
+                return !isNaN(new Date(numV).getTime());
+            }
+        }
+        // 非时间戳，且长度在yyyy-mm-dd 至 yyyy-mm-dd hh:mm:ss 之间
+        if (value.length < 10 || value.length > 19) {
+            return false;
+        }
+        const dateRegex =
+            /^\d{4}[-\/]\d{2}[-\/]\d{2}( \d{1,2}:\d{2}(:\d{2})?)?$/;
+        if (!dateRegex.test(value)) {
+            return false;
+        }
+        // 检查是否为有效日期
+        const dateValue = new Date(value);
+        return !isNaN(dateValue.getTime());
+    }
+    // 非number和string类型，不做校验
+    return false;
 }
 
 /**
  * 验证ISO类型的日期格式
  */
 export function dateISO(value) {
-    return /^\d{4}[\/\-](0?[1-9]|1[012])[\/\-](0?[1-9]|[12][0-9]|3[01])$/.test(value)
+    return /^\d{4}[\/\-](0?[1-9]|1[012])[\/\-](0?[1-9]|[12][0-9]|3[01])$/.test(
+        value
+    );
 }
 
 /**
  * 验证十进制数字
  */
 export function number(value) {
-    return /^[\+-]?(\d+\.?\d*|\.\d+|\d\.\d+e\+\d+)$/.test(value)
+    return /^[\+-]?(\d+\.?\d*|\.\d+|\d\.\d+e\+\d+)$/.test(value);
 }
 
 /**
  * 验证字符串
  */
 export function string(value) {
-    return typeof value === 'string'
+    return typeof value === "string";
 }
 
 /**
  * 验证整数
  */
 export function digits(value) {
-    return /^\d+$/.test(value)
+    return /^\d+$/.test(value);
 }
 
 /**
@@ -64,7 +98,7 @@ export function digits(value) {
 export function idCard(value) {
     return /^[1-9]\d{5}[1-9]\d{3}((0\d)|(1[0-2]))(([0|1|2]\d)|3[0-1])\d{3}([0-9]|X)$/.test(
         value
-    )
+    );
 }
 
 /**
@@ -72,15 +106,18 @@ export function idCard(value) {
  */
 export function carNo(value) {
     // 新能源车牌
-    const xreg = /^[京津沪渝冀豫云辽黑湘皖鲁新苏浙赣鄂桂甘晋蒙陕吉闽贵粤青藏川宁琼使领A-Z]{1}[A-Z]{1}(([0-9]{5}[DF]$)|([DF][A-HJ-NP-Z0-9][0-9]{4}$))/
+    const xreg =
+        /^[京津沪渝冀豫云辽黑湘皖鲁新苏浙赣鄂桂甘晋蒙陕吉闽贵粤青藏川宁琼使领A-Z]{1}[A-Z]{1}(([0-9]{5}[DF]$)|([DF][A-HJ-NP-Z0-9][0-9]{4}$))/;
     // 旧车牌
-    const creg = /^[京津沪渝冀豫云辽黑湘皖鲁新苏浙赣鄂桂甘晋蒙陕吉闽贵粤青藏川宁琼使领A-Z]{1}[A-Z]{1}[A-HJ-NP-Z0-9]{4}[A-HJ-NP-Z0-9挂学警港澳]{1}$/
+    const creg =
+        /^[京津沪渝冀豫云辽黑湘皖鲁新苏浙赣鄂桂甘晋蒙陕吉闽贵粤青藏川宁琼使领A-Z]{1}[A-Z]{1}[A-HJ-NP-Z0-9]{4}[A-HJ-NP-Z0-9挂学警港澳]{1}$/;
     if (value.length === 7) {
-        return creg.test(value)
-    } if (value.length === 8) {
-        return xreg.test(value)
+        return creg.test(value);
     }
-    return false
+    if (value.length === 8) {
+        return xreg.test(value);
+    }
+    return false;
 }
 
 /**
@@ -88,22 +125,22 @@ export function carNo(value) {
  */
 export function amount(value) {
     // 金额，只允许保留两位小数
-    return /^[1-9]\d*(,\d{3})*(\.\d{1,2})?$|^0\.\d{1,2}$/.test(value)
+    return /^[1-9]\d*(,\d{3})*(\.\d{1,2})?$|^0\.\d{1,2}$/.test(value);
 }
 
 /**
  * 中文
  */
 export function chinese(value) {
-    const reg = /^[\u4e00-\u9fa5]+$/gi
-    return reg.test(value)
+    const reg = /^[\u4e00-\u9fa5]+$/gi;
+    return reg.test(value);
 }
 
 /**
  * 只能输入字母
  */
 export function letter(value) {
-    return /^[a-zA-Z]*$/.test(value)
+    return /^[a-zA-Z]*$/.test(value);
 }
 
 /**
@@ -111,37 +148,37 @@ export function letter(value) {
  */
 export function enOrNum(value) {
     // 英文或者数字
-    const reg = /^[0-9a-zA-Z]*$/g
-    return reg.test(value)
+    const reg = /^[0-9a-zA-Z]*$/g;
+    return reg.test(value);
 }
 
 /**
  * 验证是否包含某个值
  */
 export function contains(value, param) {
-    return value.indexOf(param) >= 0
+    return value.indexOf(param) >= 0;
 }
 
 /**
  * 验证一个值范围[min, max]
  */
 export function range(value, param) {
-    return value >= param[0] && value <= param[1]
+    return value >= param[0] && value <= param[1];
 }
 
 /**
  * 验证一个长度范围[min, max]
  */
 export function rangeLength(value, param) {
-    return value.length >= param[0] && value.length <= param[1]
+    return value.length >= param[0] && value.length <= param[1];
 }
 
 /**
  * 是否固定电话
  */
 export function landline(value) {
-    const reg = /^\d{3,4}-\d{7,8}(-\d{3,4})?$/
-    return reg.test(value)
+    const reg = /^\d{3,4}-\d{7,8}(-\d{3,4})?$/;
+    return reg.test(value);
 }
 
 /**
@@ -149,67 +186,68 @@ export function landline(value) {
  */
 export function empty(value) {
     switch (typeof value) {
-    case 'undefined':
-        return true
-    case 'string':
-        if (value.replace(/(^[ \t\n\r]*)|([ \t\n\r]*$)/g, '').length == 0) return true
-        break
-    case 'boolean':
-        if (!value) return true
-        break
-    case 'number':
-        if (value === 0 || isNaN(value)) return true
-        break
-    case 'object':
-        if (value === null || value.length === 0) return true
-        for (const i in value) {
-            return false
-        }
-        return true
+        case "undefined":
+            return true;
+        case "string":
+            if (value.replace(/(^[ \t\n\r]*)|([ \t\n\r]*$)/g, "").length == 0)
+                return true;
+            break;
+        case "boolean":
+            if (!value) return true;
+            break;
+        case "number":
+            if (value === 0 || isNaN(value)) return true;
+            break;
+        case "object":
+            if (value === null || value.length === 0) return true;
+            for (const i in value) {
+                return false;
+            }
+            return true;
     }
-    return false
+    return false;
 }
 
 /**
  * 是否json字符串
  */
 export function jsonString(value) {
-    if (typeof value === 'string') {
+    if (typeof value === "string") {
         try {
-            const obj = JSON.parse(value)
-            if (typeof obj === 'object' && obj) {
-                return true
+            const obj = JSON.parse(value);
+            if (typeof obj === "object" && obj) {
+                return true;
             }
-            return false
+            return false;
         } catch (e) {
-            return false
+            return false;
         }
     }
-    return false
+    return false;
 }
 
 /**
  * 是否数组
  */
 export function array(value) {
-    if (typeof Array.isArray === 'function') {
-        return Array.isArray(value)
+    if (typeof Array.isArray === "function") {
+        return Array.isArray(value);
     }
-    return Object.prototype.toString.call(value) === '[object Array]'
+    return Object.prototype.toString.call(value) === "[object Array]";
 }
 
 /**
  * 是否对象
  */
 export function object(value) {
-    return Object.prototype.toString.call(value) === '[object Object]'
+    return Object.prototype.toString.call(value) === "[object Object]";
 }
 
 /**
  * 是否短信验证码
  */
 export function code(value, len = 6) {
-    return new RegExp(`^\\d{${len}}$`).test(value)
+    return new RegExp(`^\\d{${len}}$`).test(value);
 }
 
 /**
@@ -217,7 +255,7 @@ export function code(value, len = 6) {
  * @param {Object} value
  */
 export function func(value) {
-    return typeof value === 'function'
+    return typeof value === "function";
 }
 
 /**
@@ -225,16 +263,16 @@ export function func(value) {
  * @param {Object} value
  */
 export function promise(value) {
-    return object(value) && func(value.then) && func(value.catch)
+    return object(value) && func(value.then) && func(value.catch);
 }
 
 /** 是否图片格式
  * @param {Object} value
  */
 export function image(value) {
-    const newValue = value.split('?')[0]
-    const IMAGE_REGEXP = /\.(jpeg|jpg|gif|png|svg|webp|jfif|bmp|dpg)/i
-    return IMAGE_REGEXP.test(newValue)
+    const newValue = value.split("?")[0];
+    const IMAGE_REGEXP = /\.(jpeg|jpg|gif|png|svg|webp|jfif|bmp|dpg)/i;
+    return IMAGE_REGEXP.test(newValue);
 }
 
 /**
@@ -242,8 +280,9 @@ export function image(value) {
  * @param {Object} value
  */
 export function video(value) {
-    const VIDEO_REGEXP = /\.(mp4|mpg|mpeg|dat|asf|avi|rm|rmvb|mov|wmv|flv|mkv|m3u8)/i
-    return VIDEO_REGEXP.test(value)
+    const VIDEO_REGEXP =
+        /\.(mp4|mpg|mpeg|dat|asf|avi|rm|rmvb|mov|wmv|flv|mkv|m3u8)/i;
+    return VIDEO_REGEXP.test(value);
 }
 
 /**
@@ -252,7 +291,7 @@ export function video(value) {
  * @return {Boolean}
  */
 export function regExp(o) {
-    return o && Object.prototype.toString.call(o) === '[object RegExp]'
+    return o && Object.prototype.toString.call(o) === "[object RegExp]";
 }
 
 export default {
@@ -284,5 +323,5 @@ export default {
     video,
     image,
     regExp,
-    string
-}
+    string,
+};

--- a/src/uni_modules/uview-plus/libs/function/test.uts
+++ b/src/uni_modules/uview-plus/libs/function/test.uts
@@ -23,14 +23,39 @@ export function url(value: string): boolean {
 /**
  * 验证日期格式
  */
-export function date(value: string): boolean {
-    if (value == '') return false
-    // 判断是否数值或者字符串数值(意味着为时间戳)，转为数值，否则new Date无法识别字符串时间戳
-    let valueNo = 0
-	if (number(value)) {
-		valueNo = parseInt(value)
-	}
-    return !/Invalid|NaN/.test(new Date(valueNo).toString())
+export function date(value: string | number): boolean {
+  if (value === '') return false;
+  // number类型，判断是否是时间戳
+  if (typeof value === 'number') {
+      // len === 10 秒级时间戳 len === 13 毫秒级时间戳
+      if (value.toString().length !== 10 && value.toString().length !== 13) {
+          return false;
+      }
+      return !isNaN(new Date(value).getTime());
+  }
+if (typeof value === "string") {
+    // 是否为string类型时间戳
+    const numV = Number(value);
+    if (!isNaN(numV)) {
+        if (numV.toString().length === 10 || numV.toString().length === 13) {
+            return !isNaN(new Date(numV).getTime());
+        }
+    }
+    // 非时间戳，且长度在yyyy-mm-dd 至 yyyy-mm-dd hh:mm:ss 之间
+    if (value.length < 10 || value.length > 19) {
+        return false;
+    }
+    const dateRegex =
+        /^\d{4}[-\/]\d{2}[-\/]\d{2}( \d{1,2}:\d{2}(:\d{2})?)?$/;
+    if (!dateRegex.test(value)) {
+        return false;
+    }
+    // 检查是否为有效日期
+    const dateValue = new Date(value);
+    return !isNaN(dateValue.getTime());
+}
+  // 非number和string类型，不做校验
+  return false;
 }
 
 /**


### PR DESCRIPTION
#485 传入值为`'008'`时实际上是可以通过new Date()函数正确构造出值的，只是这种场景在开发中并不常见，大多数情况下大家觉得这应该返回错误。所以我将校验内容改为了类型+长度+正则，允许对`2020-02-10`、`2020-02-10 08:32:10`、`2020/02/10 03:10`、`2020/02/10 3:10`、`2020/02-10 3:10`及时间戳进行校验。
![example](https://github.com/user-attachments/assets/99cf5865-cde8-45b5-9ee7-c868b863dee3)
