### PR TITLE
修复再cli构建项目导入至node_modules中，版本信息打印两次

### DIFF
--- a/src/uni_modules/uview-plus/libs/config/config.js
+++ b/src/uni_modules/uview-plus/libs/config/config.js
@@ -1,7 +1,7 @@
 const version = '3'
 
 // 开发环境才提示，生产环境不会提示
-if (process.env.NODE_ENV === 'development') {
+if (process.env.NODE_ENV === 'development' && !window.__versionLog__ && (window.__versionLog__ = true)) {
 	console.log(`\n %c uview-plus V${version} %c https://ijry.github.io/uview-plus/ \n\n`, 'color: #ffffff; background: #3c9cff; padding:5px 0;', 'color: #3c9cff;background: #ffffff; padding:5px 0;');
 }
 


### PR DESCRIPTION
项目由 cil 构建采用cil 安装方式使用组件情况下开发环境

 - 问题环境
     - vite 5.2.28
     - uniapp 3.0..0
     - uview-plus3.3.34

- 问题截图

![image](https://github.com/user-attachments/assets/1aa25601-eed5-4036-8a9f-db4944eca0fb)

- 问题原因
vite在hmr进行过程中会触发一次
uniapp自动导入组件easycom配置会触发一次导致两次log版本信息

- 解决办法
加入判断只log一次
