### PR TITLE
修复因为修改组件名称前缀，导致h5打包后$parent方法内找不到父组件的问题

### DIFF
--- a/src/uni_modules/uview-plus/libs/function/index.js
+++ b/src/uni_modules/uview-plus/libs/function/index.js
@@ -119,6 +119,7 @@ export function $parent(name = undefined) {
 	// 通过while历遍，这里主要是为了H5需要多层解析的问题
 	while (parent) {
 		// 父组件
+        name = name.replace(/up-([a-zA-Z0-9-_]+)/g, 'u-$1')        
 		if (parent.$options && parent.$options.name !== name) {
 			// 如果组件的name不相等，继续上一级寻找
 			parent = parent.$parent


### PR DESCRIPTION
```
// 批量注册全局组件
for (const key in importFn) {
    let component = importFn[key].default;
    if (component.name && component.name.indexOf('u--') !== 0) {
        const name = component.name.replace(/u-([a-zA-Z0-9-_]+)/g, 'up-$1');
        component.install = function (Vue) {
            Vue.component(name, component);
        };
        
        // 导入组件
        components.push(component);
    }
}
```
`uni_modules/uview-plus/index.js`中统一将组件名称前缀替换成了up-，但是组件代码找查找父组件依然用的u前缀，比如：
`
$parent.call(instance, 'u-form-item')
`
