### PR TITLE
feat: 更新u-picker组件 增加当前选中class类名

### DIFF
--- a/src/uni_modules/uview-plus/components/u-picker/u-picker.vue
+++ b/src/uni_modules/uview-plus/components/u-picker/u-picker.vue
@@ -48,6 +48,7 @@
 						<view
 							v-if="testArray(item)"
 							class="u-picker__view__column__item u-line-1"
+							:class="[index1 === innerIndex[index] && 'u-picker__view__column__item--selected']"
 							v-for="(item1, index1) in item"
 							:key="index1"
 							:style="{


### PR DESCRIPTION
u-picker组件 增加当前选中item的class类名
比起使用[style*="font-weight: bold"] { }属性选择器更为方便