### PR TITLE
up-datetime-picker日期组件支持禁用

### DIFF
--- a/src/uni_modules/uview-plus/components/u-datetime-picker/props.js
+++ b/src/uni_modules/uview-plus/components/u-datetime-picker/props.js
@@ -7,6 +7,10 @@ export const props = defineMixin({
             type: Boolean,
             default: () => false
         },
+		disabled: {
+            type: Boolean,
+            default: () => false
+        },
         placeholder: {
             type: String,
             default: () => '请选择'

--- a/src/uni_modules/uview-plus/components/u-datetime-picker/u-datetime-picker.vue
+++ b/src/uni_modules/uview-plus/components/u-datetime-picker/u-datetime-picker.vue
@@ -1,7 +1,7 @@
 <template>
     <view class="u-datetime-picker">
         <view v-if="hasInput" class="u-datetime-picker__has-input"
-            @click="showByClickInput = !showByClickInput"
+            @click="onShowByClickInput" 
         >
             <slot name="trigger" :value="inputValue">
 				<up-input
@@ -9,6 +9,7 @@
 					:readonly="!!showByClickInput"
 					border="surround"
 					v-model="inputValue"
+					:disabled="disabled"
 				></up-input>
 				<div class="input-cover">
 				</div>
@@ -461,6 +462,12 @@
 			        [`${type}Hour`]: hour,
 			        [`${type}Minute`]: minute
 			    }
+			},
+			onShowByClickInput(){
+				if(!this.disabled){
+					this.showByClickInput = !this.showByClickInput
+				}
+				
 			}
 		}
 	}


### PR DESCRIPTION
 **起因：**
 up-datetime-picker不支持disabled，但是这个功能非常的场景
 
 `<up-datetime-picker
            hasInput
            :show="show"
            v-model="value1"
            mode="datetime"
        ></up-datetime-picker>`
        
 **修改：**
 添加了disabled props      
**涉及修改的文件** 
 /uni_modulesuview-plus/components/u-datetime-picker/props.js
  /uni_modulesuview-plus/u-datetime-picker/u-datetime-picker.vue
        
        