### PR TITLE
feat: sleder滑动选择器双滑块 增加外层触发值的变动功能

### DIFF
--- a/src/uni_modules/uview-plus/components/u-slider/u-slider.vue
+++ b/src/uni_modules/uview-plus/components/u-slider/u-slider.vue
@@ -155,8 +155,17 @@
 			value(n) {
 				// 只有在非滑动状态时，才可以通过value更新滑块值，这里监听，是为了让用户触发
 				if(this.status == 'end') this.updateValue(this.value, false);
-			}
+			},
 			// #endif
+			rangeValue:{
+            	handler(n){
+					if(this.status == 'end'){
+						this.updateValue(this.rangeValue[0], false, 0);
+						this.updateValue(this.rangeValue[1], false, 1);
+					}
+            	},
+            	deep:true
+        	}
 		},
 		created() {
 		},


### PR DESCRIPTION
**问题:**
滑块选择器（slider）在双滑块模式下，当父组件修改绑定值时，滑块选择器未正确响应，导致显示状态与绑定值不同步。

**解决方法:**
通过监听绑定值的变化，实现滑块选择器与父组件绑定值的同步更新。