### PR TITLE
fix u-sticky.vue Uncaught TypeError: e.querySelector is not a functio…

### DIFF
--- a/src/uni_modules/uview-plus/components/u-sticky/u-sticky.vue
+++ b/src/uni_modules/uview-plus/components/u-sticky/u-sticky.vue
@@ -1,10 +1,10 @@
 <template>
 	<view
 		class="u-sticky"
-		:id="elId"
 		:style="[style]"
 	>
 		<view
+		:id="elId"
 			:style="[stickyContent]"
 			class="u-sticky__content"
 		>
@@ -114,7 +114,7 @@
 			observeContent() {
 				// 先断掉之前的观察
 				this.disconnectObserver('contentObserver')
-				const contentObserver = uni.createIntersectionObserver({
+				const contentObserver = uni.createIntersectionObserver(this,{
 					// 检测的区间范围
 					thresholds: [0.95, 0.98, 1]
 				})


### PR DESCRIPTION
…n at uni-app-view.umd.js

Uncaught TypeError: e.querySelector is not a function at uni-app-view.umd.js
https://github.com/dcloudio/uni-app/pull/5371