### PR TITLE
fix: u-upload

### DIFF
--- a/src/uni_modules/uview-plus/components/u-upload/utils.js
+++ b/src/uni_modules/uview-plus/components/u-upload/utils.js
@@ -89,6 +89,11 @@ export function chooseFile({
     maxCount,
     extension
 }) {
+    try {
+        capture = test.array(capture) ? capture : capture.split(',');
+    } catch(e) {
+        capture = [];
+    }
     return new Promise((resolve, reject) => {
         switch (accept) {
         case 'image':


### PR DESCRIPTION
1. 'other'类型的文件缺少with/height限制;
2. 支持显示真实的文件名;
3. u-loading-icon跟白色背景重叠;
4. 优先使用文件名判断是否是图片或视频;
5. this.onAfterRead传入参数bug;
6. 组件方法chooseFile支持传入参数以覆盖组件默认属性, 供外部组件动态调用, 提高灵活性.