### PR TITLE
fix: 修复u-image.vue在加载错误情况下高度和宽度不正确问题

### DIFF
--- a/src/uni_modules/uview-plus/components/u-image/u-image.vue
+++ b/src/uni_modules/uview-plus/components/u-image/u-image.vue
@@ -132,12 +132,12 @@
 				// #endif
 				// #ifndef APP-NVUE
 				if (this.loading || this.isError || this.width == '100%' || this.mode != 'heightFix') {
-					style.width = this.width;
+					style.width = addUnit(this.width);
 				} else {
 					style.width = 'fit-content';
 				}
 				if (this.loading || this.isError || this.height == '100%' || this.mode != 'widthFix') {
-					style.height = this.height;
+					style.height = addUnit(this.height);
 				} else {
 					style.height = 'fit-content';
 				}
@@ -153,12 +153,12 @@
 				// #endif
 				// #ifndef APP-NVUE
 				if (this.loading || this.isError || this.width == '100%' || this.mode != 'heightFix') {
-					style.width = this.width;
+					style.width = addUnit(this.width);
 				} else {
 					style.width = 'fit-content';
 				}
 				if (this.loading || this.isError || this.height == '100%' || this.mode != 'widthFix') {
-					style.height = this.height;
+					style.height = addUnit(this.height);
 				} else {
 					style.height = 'fit-content';
 				}


### PR DESCRIPTION
给`u-image.vue`的计算属性`transStyle()`和`wrapStyle()`添加了`addUnit(this.width);`和`addUnit(this.height); `

Closes:  #701 