### PR TITLE
fix:修复indexList中stikcy属性写死的问题(always true)

### DIFF
--- a/src/uni_modules/uview-plus/components/u-index-anchor/u-index-anchor.vue
+++ b/src/uni_modules/uview-plus/components/u-index-anchor/u-index-anchor.vue
@@ -4,6 +4,7 @@
 	<!-- #endif -->
 	<view
 	    class="u-index-anchor u-border-bottom"
+		:class="{ 'u-index-anchor--sticky': parentSticky }"
 		:ref="`u-index-anchor-${text}`"
 	    :style="{
 			height: addUnit(height),
@@ -73,6 +74,12 @@
 				// #endif
 			}
 		},
+		computed: {
+        parentSticky() {
+            const indexList = $parent.call(this, "u-index-list");
+            return indexList ? indexList.sticky : true;
+        	},
+		},
 	}
 </script>
 
@@ -85,6 +92,11 @@
 		align-items: center;
 		padding-left: 15px;
 		z-index: 1;
+
+		&--sticky {
+        position: sticky;
+        top: 0;
+    	}
 
 		&__text {
 			@include flex;


### PR DESCRIPTION
已验证 h5+微信小程序
之前的代码，因为index-anchor里面把position写死成sticky了（position: sticky），所以sticky prop是false的情况下锚点依旧是吸顶的，不会改成不吸顶

h5验证截图：
![h5-test](https://github.com/user-attachments/assets/49d03a20-cc05-4007-934c-649edbafb66f)

微信小程序验证截图:
![wechat-test](https://github.com/user-attachments/assets/3bebf8e7-1963-40d2-83df-dc3fbc5e8f41)
