### PR TITLE
fix:修复indexList中丢失的select event

### DIFF
--- a/src/uni_modules/uview-plus/components/u-index-list/u-index-list.vue
+++ b/src/uni_modules/uview-plus/components/u-index-list/u-index-list.vue
@@ -389,6 +389,7 @@
 				// 如果偏移量太小，前后得出的会是同一个索引字母，为了防抖，进行返回
 				if (currentIndex === this.activeIndex) return
 				this.activeIndex = currentIndex
+				this.$emit('select', this.uIndexList[currentIndex])
 				// #ifndef APP-NVUE || MP-WEIXIN
 				// 在非nvue中，由于anchor和item都在u-index-item中，所以需要对index-item进行偏移
 				this.scrollIntoView = `u-index-item-${this.uIndexList[currentIndex].charCodeAt(0)}`


### PR DESCRIPTION
我看说明文档里面，点击右侧索引文字的时候应该是会有一个select event的，但是看了一眼源码里好像没有？不确定是不是以前源码里有但是后面删掉了，但是文档还没更新，我看其他组件里也有这样的情况。

这个是indexList组件文档里的描述：
事件名 | 说明 | 回调参数 | 版本
-- | -- | -- | --
select | 选中右边索引字符时触发 | index: 索引字符 | -

如果需要这个event的话，那我已在h5和微信小程序测试：
h5:
![h5-test](https://github.com/user-attachments/assets/f35dd423-bf98-4972-a717-a9821ff437d7)
微信:
![weixin-test](https://github.com/user-attachments/assets/99a2a565-49ed-4b8a-84e8-63ba7fd6121c)
