### PR TITLE
feat: Subsection 分段器添加支持从 list中读取激活文字颜色和未激活文字颜色

### DIFF
--- a/src/pages/componentsC/subsection/subsection.nvue
+++ b/src/pages/componentsC/subsection/subsection.nvue
@@ -46,6 +46,19 @@
 				></up-subsection>
 			</view>
 		</view>
+
+        <view class="u-demo-block">
+            <text class="u-demo-block__title">按钮模式通过list自定义颜色</text>
+            <view class="u-demo-block__content">
+                <up-subsection
+                    :list="list3"
+                    mode="button"
+                    activeColorKeyName="textColor"
+                    :current="current5"
+                    @change="change5"
+                ></up-subsection>
+            </view>
+        </view>
 	</view>
 </template>
 
@@ -57,7 +70,22 @@
 				current2: 0,
 				current3: 0,
 				current4: 1,
+                current5: 0,
 				list: ['未付款', '待评价', '已付款'],
+                list3: [
+                    {
+                        name: '禁用',
+                        textColor: '#FF4D4D',
+                    },
+                    {
+                        name: '启用',
+                        textColor: '#00CC88',
+                    },
+                    {
+                        name: '未激活文字',
+                        inactiveColorKey : 'pink',
+                    }
+                ],
 				// 或者如下，也可以配置keyName参数修改对象键值
 				// list: [{name: '未付款'}, {name: '待评价'}, {name: '已付款'}],
 				current: 1
@@ -75,6 +103,9 @@
 			},
 			change4(index) {
 				this.current4 = index
+			},
+            change5(index) {
+				this.current5 = index
 			}
 		},
 	}

--- a/src/uni_modules/uview-plus/components/u-subsection/props.js
+++ b/src/uni_modules/uview-plus/components/u-subsection/props.js
@@ -1,5 +1,6 @@
-import { defineMixin } from '../../libs/vue'
+import {defineMixin} from '../../libs/vue'
 import defProps from '../../libs/config/props.js'
+
 export const props = defineMixin({
     props: {
         // tab的数据
@@ -42,10 +43,20 @@ export const props = defineMixin({
             type: String,
             default: () => defProps.subsection.bgColor
         },
-		// 从list元素对象中读取的键名
-		keyName: {
-			type: String,
-			default: () => defProps.subsection.keyName
-		}
+        // 从list元素对象中读取的键名
+        keyName: {
+            type: String,
+            default: () => defProps.subsection.keyName
+        },
+        // 从`list`元素对象中读取激活时的颜色  如果存在字段 优先级大于 activeColor
+        activeColorKeyName: {
+            type: String,
+            default: () => defProps.subsection.activeColorKeyName
+        },
+        // 从`list`元素对象中读取未激活时的颜色 如果存在字段 优先级大于 inactiveColor
+        inactiveColorKeyName: {
+            type: String,
+            default: () => defProps.subsection.inactiveColorKeyName
+        }
     }
 })

--- a/src/uni_modules/uview-plus/components/u-subsection/subsection.js
+++ b/src/uni_modules/uview-plus/components/u-subsection/subsection.js
@@ -18,6 +18,8 @@ export default {
         fontSize: 12,
         bold: true,
         bgColor: '#eeeeef',
-		keyName: 'name'
+        keyName: 'name',
+        activeColorKeyName: 'activeColorKey',
+        inactiveColorKeyName: 'inactiveColorKey',
     }
 }

--- a/src/uni_modules/uview-plus/components/u-subsection/u-subsection.vue
+++ b/src/uni_modules/uview-plus/components/u-subsection/u-subsection.vue
@@ -40,7 +40,7 @@
         >
             <text
                 class="u-subsection__item__text"
-                :style="[textStyle(index)]"
+                :style="[textStyle(index,item)]"
                 >{{ getText(item) }}</text
             >
         </view>
@@ -158,22 +158,46 @@ export default {
             };
         },
         // 分段器文字颜色
-        textStyle(index) {
-            return (index) => {
+        textStyle(index,item) {
+            return (index,item) => {
                 const style = {};
                 style.fontWeight =
                     this.bold && this.innerCurrent === index ? "bold" : "normal";
                 style.fontSize = addUnit(this.fontSize);
+
+                let activeColorTemp = null;
+                let inactiveColorTemp = null;
+                // 如果是对象并且设置了对应的背景色字段 则优先使用设置的字段
+                if(typeof item === 'object' && item[this.activeColorKeyName]){
+                    activeColorTemp = item[this.activeColorKeyName];
+                }
+                if(typeof item === 'object' && item[this.inactiveColorKeyName]){
+                    inactiveColorTemp = item[this.inactiveColorKeyName];
+                }
+
                 // subsection模式下，激活时默认为白色的文字
                 if (this.mode === "subsection") {
-                    style.color =
-                        this.innerCurrent === index ? "#fff" : this.inactiveColor;
-                } else {
+                    // 判断当前是否激活
+                    if(this.innerCurrent === index){
+                        // 判断当前是否有自定义的颜色
+                        style.color = activeColorTemp ? activeColorTemp : '#FFF'
+                        // style.color = activeColorTemp ? activeColorTemp : this.activeColor
+                    }
+                    else{
+                        // 判断当前是否有自定义的颜色
+                        style.color = inactiveColorTemp ? inactiveColorTemp : this.inactiveColor;
+                    }
+                }
+                else {
                     // button模式下，激活时文字颜色默认为activeColor
-                    style.color =
-                        this.innerCurrent === index
-                            ? this.activeColor
-                            : this.inactiveColor;
+                    if(this.innerCurrent === index){
+                        // 判断当前是否有自定义的颜色
+                        style.color = activeColorTemp ? activeColorTemp : this.activeColor
+                    }
+                    else{
+                        // 判断当前是否有自定义的颜色
+                        style.color = inactiveColorTemp ? inactiveColorTemp : this.inactiveColor;
+                    }
                 }
                 return style;
             };

--- a/src/uni_modules/uview-plus/types/comps/subsection.d.ts
+++ b/src/uni_modules/uview-plus/types/comps/subsection.d.ts
@@ -46,6 +46,17 @@ declare interface SubsectionProps {
    * @default "name"
    */
   keyName?: string
+
+  /**
+   * 从`list`元素对象中读取激活时的颜色  如果存在字段 优先级大于 activeColor
+   * @default activeColorKey
+   */
+  activeColorKeyName?: string
+  /**
+   * 从`list`元素对象中读取未激活时的颜色 如果存在字段 优先级大于 inactiveColor
+   * @default inactiveColorKey
+   */
+  inactiveColorKeyName?: string
   /**
    * 分段器选项发生改变时触发
    * @param index 选项的index索引值，从0开始


### PR DESCRIPTION
close #780 
activeColorKeyName 从`list`元素对象中读取激活时的颜色  如果存在字段 优先级大于 activeColor
inactiveColorKeyName 从`list`元素对象中读取未激活时的颜色 如果存在字段 优先级大于 inactiveColor


h5验证：同步更新demo 
![image](https://github.com/user-attachments/assets/cdd77fa1-7f14-420c-a1e4-02b32a999964)
![image](https://github.com/user-attachments/assets/87f863bf-856b-4f2b-a8e3-d4416002ac8a)
![image](https://github.com/user-attachments/assets/22c6daf6-e4f4-450c-9f70-558e26ed931f)
