### PR TITLE
fix: 官方文档和小程序中Card示例组件多行显示省略号样式异常

### DIFF
--- a/src/pages/componentsB/card/card.vue
+++ b/src/pages/componentsB/card/card.vue
@@ -5,7 +5,7 @@
 				:sub-title="subTitle" :thumb="thumb" :padding="padding" :border="border">
 				<template #body>
 					<view>
-						<view class="u-body-item u-flex u-border-bottom u-col-between u-p-t-0">
+						<view class="u-body-item u-flex u-flex-items-start u-border-bottom u-col-between u-p-t-0">
 							<view class="u-body-item-title u-line-2">瓶身描绘的牡丹一如你初妆，冉冉檀香透过窗心事我了然，宣纸上走笔至此搁一半</view>
 							<image src="https://img12.360buyimg.com/n7/jfs/t1/102191/19/9072/330688/5e0af7cfE17698872/c91c00d713bf729a.jpg" mode="aspectFill"></image>
 						</view>


### PR DESCRIPTION
fix: #786
这个PR是为了解决官方文档和小程序中Card示例组件多行显示省略号样式异常
效果图对比
修改前
![image](https://github.com/user-attachments/assets/b318b00b-262e-47c6-9fbf-718a5486f392)
修改后
![image](https://github.com/user-attachments/assets/90a3d7e2-a270-445f-9eda-f60175ff3d19)
