### PR TITLE
bugfix: 修复u-safe-bottom在小程序中产生双倍安全区的问题：

### DIFF
--- a/src/uni_modules/uview-plus/components/u-safe-bottom/u-safe-bottom.vue
+++ b/src/uni_modules/uview-plus/components/u-safe-bottom/u-safe-bottom.vue
@@ -34,7 +34,7 @@
 		computed: {
 			style() {
 				const style = {};
-				// #ifdef APP-NVUE || MP
+				// #ifdef APP-NVUE
 				// nvue下，高度使用js计算填充
 				style.height = addUnit(getWindowInfo().safeAreaInsets.bottom, 'px');
 				// #endif


### PR DESCRIPTION
1.在小程序模式下，会同时被u-safe-area-inset-bottom和style.height = addUnit(getWindowInfo().safeAreaInsets.bottom, 'px');添加两次安全高度 

2.考虑到uni.getWindowInfo()函数在众多小程序中只有微信小程序支持，因此修改后，小程序使用class u-safe-area-inset-bottom，不再添加style.height