### PR TITLE
🐞 fix(u-qrcode): 解决大写cid导致的无法获取node

### DIFF
--- a/src/uni_modules/uview-plus/components/u-qrcode/u-qrcode.vue
+++ b/src/uni_modules/uview-plus/components/u-qrcode/u-qrcode.vue
@@ -296,7 +296,7 @@ export default {
                 // #endif
 
                 // #ifndef MP-TOUTIAO || H5 || APP-PLUS
-                const canvas = await this.getNode(this.cId,true);
+                const canvas = await this.getNode(this.cid,true);
                 uni.canvasToTempFilePath(
                     {
                         canvas,


### PR DESCRIPTION
长按回调目前导致了报错,经查看是cid大写导致的