### PR TITLE
fix: 修复u-form-item组件缺少对labelPosition的判断

### DIFF
--- a/src/uni_modules/uview-plus/components/u-form-item/u-form-item.vue
+++ b/src/uni_modules/uview-plus/components/u-form-item/u-form-item.vue
@@ -15,7 +15,7 @@
 					v-if="required || leftIcon || label"
 					:style="{
 						width: addUnit(labelWidth || parentData.labelWidth),
-						marginBottom: parentData.labelPosition === 'left' ? 0 : '5px',
+						marginBottom: (labelPosition || parentData.labelPosition) === 'left' ? 0 : '5px',
 					}"
 				>
 					<!-- 为了块对齐 -->
@@ -62,7 +62,7 @@
 				v-if="!!message && parentData.errorType === 'message'"
 				class="u-form-item__body__right__message"
 				:style="{
-					marginLeft:  addUnit(parentData.labelPosition === 'top' ? 0 : (labelWidth || parentData.labelWidth))
+					marginLeft:  addUnit((labelPosition || parentData.labelPosition) === 'top' ? 0 : (labelWidth || parentData.labelWidth))
 				}"
 			>{{ message }}</text>
 		</slot>


### PR DESCRIPTION
Fix #805 

修复u-form-item组件缺少对labelPosition的判断

u-form-item组件`labelPosition`设置为`top`

修改前
<img width="167" height="61" alt="{FAE50C71-E20A-40BB-A9B7-740DC2389BB5}" src="https://github.com/user-attachments/assets/afead21f-ba41-4605-9a94-9bacd43f8b0b" />

修改后
<img width="167" height="60" alt="{1714EC94-3E0E-4540-9169-D46BD7155826}" src="https://github.com/user-attachments/assets/38a7fb47-4edf-4302-a3b8-8d13aa96a956" />
