### PR TITLE
fix:修复u-dropdown组件在打开下拉菜单时content高度为NANpx的问题.

### DIFF
--- a/src/uni_modules/uview-plus/libs/function/index.js
+++ b/src/uni_modules/uview-plus/libs/function/index.js
@@ -66,10 +66,10 @@ export function sys() {
 }
 export function getWindowInfo() {
 	let ret = {}
-	// #ifdef APP || H5 || MP-WEIXIN
+	// #ifdef APP || H5
 	ret = uni.getWindowInfo()
 	// #endif
-	// #ifndef APP || H5 || MP-WEIXIN
+	// #ifndef APP || H5
 	ret = sys()
 	// #endif
 	return ret


### PR DESCRIPTION
在小程序中会调用sys()而不是调用uni.getWindowInfo()