### PR TITLE
✨ feat(u-index-list): 增加下边距高度

### DIFF
--- a/src/uni_modules/uview-plus/components/u-index-list/indexList.js
+++ b/src/uni_modules/uview-plus/components/u-index-list/indexList.js
@@ -16,6 +16,6 @@ export default {
         sticky: true,
         customNavHeight: 0,
         safeBottomFix: false,
-        itemMarginRpx: '0rpx'
+        itemMargin: '0rpx'
     }
 }

--- a/src/uni_modules/uview-plus/components/u-index-list/props.js
+++ b/src/uni_modules/uview-plus/components/u-index-list/props.js
@@ -32,9 +32,10 @@ export const props = defineMixin({
             type: Boolean,
             default: () => defProps.indexList.safeBottomFix
         },
-        itemMarginRpx: {
+        //自定义下边距
+        itemMargin: {
             type: String,
-            default: () => defProps.indexList.itemMarginRpx
+            default: () => defProps.indexList.itemMargin
         },
     }
 })

--- a/src/uni_modules/uview-plus/components/u-index-list/u-index-list.vue
+++ b/src/uni_modules/uview-plus/components/u-index-list/u-index-list.vue
@@ -411,7 +411,7 @@
 				const anchors = this.anchors
 				// 由于list组件无法获取cell的top值，这里通过header slot和各个item之间的height，模拟出类似非nvue下的位置信息
 				let children = this.children.map((item, index) => {
-					const childHeight = item.height + getPx(this.itemMarginRpx)
+					const childHeight = item.height + getPx(this.itemMargin)
 					const child = {
 						height: childHeight,
 						top: top
@@ -495,7 +495,7 @@
 				const anchors = this.anchors
 				// 由于list组件无法获取cell的top值，这里通过header slot和各个item之间的height，模拟出类似非nvue下的位置信息
 				children = this.children.map((item, index) => {
-					const childHeight = item.height + getPx(this.itemMarginRpx)
+					const childHeight = item.height + getPx(this.itemMargin)
 					const child = {
 						height: childHeight,
 						top: top


### PR DESCRIPTION
自定义了u-index-item后给了一个下边距,导致索引点击后对应的位置错误,增加下边距高度字段,默认0rpx
<img width="358" height="559" alt="image" src="https://github.com/user-attachments/assets/5723884a-306c-47ad-8fda-9499c9c600b9" />
