### PR TITLE
fix: 修复action-sheet列表中第一个item的hover style

### DIFF
--- a/src/uni_modules/uview-plus/components/u-action-sheet/u-action-sheet.vue
+++ b/src/uni_modules/uview-plus/components/u-action-sheet/u-action-sheet.vue
@@ -65,6 +65,7 @@
 							    @tap.stop="selectHandler(index)"
 							    :hover-class="!item.disabled && !item.loading ? 'u-action-sheet--hover' : ''"
 							    :hover-stay-time="150"
+							    :style="getItemHoverStyle(index)"
 							>
 								<template v-if="!item.loading">
 									<text
@@ -198,6 +199,16 @@
 						this.$emit('close')
 					}
 				}
+			},
+			// 动态处理Hover时候第一个item的圆角
+			getItemHoverStyle(index) {
+				if (index === 0 && this.round && !this.title && !this.description) {
+					return {
+						borderTopLeftRadius: `${this.round}px`,
+						borderTopRightRadius: `${this.round}px`,
+					}
+				}
+				return {}
 			},
 		}
 	}


### PR DESCRIPTION
如果给action-sheet设置了圆角（<up-action-sheet round="10" >)，且不带标题，那hover第一个列表item的时候，原本有的圆角就会消失，改了下hover style就好了
未修改之前的截图：
带圆角的列表：
<img width="817" height="1496" alt="1" src="https://github.com/user-attachments/assets/706a680b-c0e8-4155-a837-ab0566c2adee" />
带圆角列表第一个item的hover style:
<img width="880" height="1515" alt="2" src="https://github.com/user-attachments/assets/d120ffa2-d831-47de-ab4b-6b716f4ae078" />
修改后的效果：
<img width="790" height="1459" alt="3" src="https://github.com/user-attachments/assets/b7ecb3d2-1b4f-4362-b8ae-280922b6757a" />
