### PR TITLE
🐞 fix(索引列表):解决初始化时获取不到高度导致的字母列表异常

### DIFF
--- a/src/uni_modules/uview-plus/components/u-index-list/u-index-list.vue
+++ b/src/uni_modules/uview-plus/components/u-index-list/u-index-list.vue
@@ -284,8 +284,10 @@
 				return new Promise(resolve => {
 					// 延时一定时间，以获取dom尺寸
 					// #ifndef APP-NVUE
-					this.$uGetRect('.u-index-list__scroll-view').then(size => {
-						resolve(size)
+					this.$nextTick(() => {
+						this.$uGetRect('.u-index-list__scroll-view').then(size => {
+							resolve(size)
+						})
 					})
 					// #endif
 


### PR DESCRIPTION
微信开发工具,以及一些比较卡的手机上,无法获取到高度,增加nexttick保证获取到正确的高度