### PR TITLE
fix: 修复tabs添加activeStyle切换后滑块无法居中

### DIFF
--- a/src/uni_modules/uview-plus/components/u-tabs/u-tabs.vue
+++ b/src/uni_modules/uview-plus/components/u-tabs/u-tabs.vue
@@ -239,7 +239,9 @@
 				// 如果点击当前不触发change
 				if (this.innerCurrent == index) return
 				this.innerCurrent = index
-				this.resize()
+                this.$nextTick(() => {
+                    this.resize()
+                })
 				this.$emit('update:current', index)
 				this.$emit('change', {
 					...item,


### PR DESCRIPTION
修复tabs添加activeStyle切换后滑块无法居中，rect的width是样式应用前的宽度
<img width="520" height="464" alt="Snipaste_2025-11-07_20-51-13" src="https://github.com/user-attachments/assets/5c0c4b10-6808-4b0b-9b2e-4c999b698e2e" />
<img width="507" height="471" alt="Snipaste_2025-11-07_20-51-51" src="https://github.com/user-attachments/assets/1b0fb209-b9c5-4bf9-b24f-9a0aa0c47ccf" />

> fix #906 