### PR TITLE
fix:修复将u-empty的mode设置为wifi后图标不能显示的问题

### DIFF
--- a/src/uni_modules/uview-plus/components/u-icon/icons.js
+++ b/src/uni_modules/uview-plus/components/u-icon/icons.js
@@ -203,6 +203,7 @@ export default {
     'uicon-empty-list': '\ue68b',
     'uicon-empty-page': '\ue627',
     'uicon-empty-order': '\ue639',
+    'uicon-empty-wifi': '\ue668',
     'uicon-man': '\ue697',
     'uicon-woman': '\ue69c',
     'uicon-man-add': '\ue61c',


### PR DESCRIPTION
icons.js 遗漏了 `uicon-empty-wifi` ，导致 `<up-empty mode="wifi" />` 不能正常显示图标