### PR TITLE
fix: 修复cascader已选中三级菜单后再选择二级菜单时，tabs报错问题

### DIFF
--- a/src/uni_modules/uview-plus/components/u-cascader/u-cascader.vue
+++ b/src/uni_modules/uview-plus/components/u-cascader/u-cascader.vue
@@ -243,9 +243,7 @@
 				this.$set(this.selectedValueIndexs, levelIndex, index);
 				
 				// 清除后续级别的选中值
-				for (let i = levelIndex + 1; i < this.selectedValueIndexs.length; i++) {
-					this.$set(this.selectedValueIndexs, i, undefined);
-				}
+				this.selectedValueIndexs.splice(levelIndex + 1)
 				
 				// 获取当前选中项
 				const currentItem = this.levelList[levelIndex][index];


### PR DESCRIPTION
版本3.6.22，组件cascader依次选中三级地址菜单后再重新选择二级菜单时，tabs报错、显示错误。
https://uview-plus.lingyun.net/components/cascader.html文档组件可复现
<img width="1928" height="796" alt="ff6fbe75-0ff2-4d7b-bed9-054692d9df24" src="https://github.com/user-attachments/assets/57889d2e-d1c4-4c3b-9a8b-cc16cb7bdd22" />
原代码`for (let i = levelIndex + 1; i < this.selectedValueIndexs.length; i++) {
					this.$set(this.selectedValueIndexs, i, undefined);
				}`
不改变数组长度。
调整为`this.selectedValueIndexs.splice(levelIndex + 1)`可修复bug