### PR TITLE
fix: 修复cascader已选中三级菜单后再选择二级菜单时，tabs报错问题

### DIFF
--- a/src/uni_modules/uview-plus/components/u-cascader/u-cascader.vue
+++ b/src/uni_modules/uview-plus/components/u-cascader/u-cascader.vue
@@ -243,9 +243,7 @@
 				this.$set(this.selectedValueIndexs, levelIndex, index);
 				
 				// 清除后续级别的选中值
-				for (let i = levelIndex + 1; i < this.selectedValueIndexs.length; i++) {
-					this.$set(this.selectedValueIndexs, i, undefined);
-				}
+				this.selectedValueIndexs.splice(levelIndex + 1);
 				
 				// 获取当前选中项
 				const currentItem = this.levelList[levelIndex][index];


### PR DESCRIPTION
版本3.6.22，组件级联依次选中三级地址菜单之后再次选择二级菜单时，选项卡报错、显示错误。
[https://uview-plus.lingyun.net/components/cascader.html](url)
组件文档可复现
<img width="1928" height="796" alt="ff6fbe75-0ff2-4d7b-bed9-054692d9df24" src="https://github.com/user-attachments/assets/476b81b2-d627-47fa-ae6e-05b378246c80" />
原代码如下:
`for (let i = levelIndex + 1; i < this.selectedValueIndexs.length; i++) {
					this.$set(this.selectedValueIndexs, i, undefined);
				}`
未改变数组长度。
修改后为：
`this.selectedValueIndexs.splice(levelIndex + 1);`
<img width="448" height="587" alt="image" src="https://github.com/user-attachments/assets/4c59d24e-086e-4528-9064-566823acd0c5" />
