### PR TITLE
fix: 修复cascader对列表数据层级差异的兼容问题

### DIFF
--- a/src/uni_modules/uview-plus/components/u-cascader/u-cascader.vue
+++ b/src/uni_modules/uview-plus/components/u-cascader/u-cascader.vue
@@ -244,6 +244,10 @@
 				
 				// 清除后续级别的选中值
 				this.selectedValueIndexs.splice(levelIndex + 1);
+				this.tabsIndex = Math.min(this.tabsIndex, levelIndex);
+				
+				// 清除后续级别的列表
+				this.levelList.splice(levelIndex + 1);
 				
 				// 获取当前选中项
 				const currentItem = this.levelList[levelIndex][index];


### PR DESCRIPTION
版本3.6.24，组件https://uview-plus.lingyun.net/components/cascader.html
对于层级不同的数据来回切换导致的报错和显示问题；
<img width="1160" height="773" alt="1" src="https://github.com/user-attachments/assets/6711a596-7219-4345-9385-b95799e71b85" />
<img width="1414" height="820" alt="2" src="https://github.com/user-attachments/assets/0a1a21c6-1919-4e01-8900-deba8e5617be" />

复现步骤：先选择一个有四层层级的数据的第四级，再选择其他三层层级的数据就会报错，因为相应的组件参数没有更新；
在选中新的列表项时，修改当前选中的tabs为之前的选择项和当前点击列表项的层级中的最小数；
`this.tabsIndex = Math.min(this.tabsIndex, levelIndex);`
同时清除比当前选中层级高的列表数据；
`this.levelList.splice(levelIndex + 1);`
附可复现测试数据：`[
        {
            "value": "41",
            "label": "河北省",
            "children": [
                {
                    "value": "65",
                    "label": "唐山市",
                    "children": [
                        {
                            "value": "42",
                            "label": "封北区"
                        },
                        {
                            "value": "111",
                            "label": "丰南区",
                            "children": [
                                {
                                    "value": "70",
                                    "label": "青年路街道"
                                }]
                        }]
                }
            ]
        }
    ]`