### PR TITLE
修復grid布局由于内容溢出导致形变

### DIFF
--- a/src/uni_modules/uview-plus/components/u-grid/u-grid.vue
+++ b/src/uni_modules/uview-plus/components/u-grid/u-grid.vue
@@ -107,7 +107,7 @@
 		/* #ifndef APP-NVUE */
 		display: grid !important;
 		grid-gap: v-bind(gap);
-		grid-template-columns: repeat(v-bind(col), 1fr);
+		grid-template-columns: repeat(v-bind(col), minmax(0, 1fr));
 		/* #endif */
 	}
 </style>


### PR DESCRIPTION
直接使用fr，当内容宽度不一致，内容溢出时，grid布局会出现形变，通过将原有写死的 1fr  改为 minmax(0, 1fr) 解决内容溢出后，grid布局形变的问题