### PR TITLE
fix: 🐛 修复u-list在支付宝小程序无法触发scrolltolower

### DIFF
--- a/src/pages/componentsC/list/list.nvue
+++ b/src/pages/componentsC/list/list.nvue
@@ -54,10 +54,11 @@
 		methods: {
 			scrollToLower() {
 				console.log('scrollToLower到外部啦')
+				 this.loadmore()
 			},
 			scrolltolower() {
 				console.log('scrolltolower 外部到啦')
-				
+				//this.loadmore()
 			},
 
 			scrolltoupper() {

--- a/src/pages/componentsC/list/list.nvue
+++ b/src/pages/componentsC/list/list.nvue
@@ -1,7 +1,11 @@
 <template>
 	<view class="u-page">
 		<up-list
+
+			@scroll-to-lower="scrollToLower"
 			@scrolltolower="scrolltolower"
+			@scrolltoupper="scrolltoupper"
+		
 		>
 			<up-list-item
 				v-for="(item, index) in indexList"
@@ -48,8 +52,16 @@
 			this.loadmore()
 		},
 		methods: {
+			scrollToLower() {
+				console.log('scrollToLower到外部啦')
+			},
 			scrolltolower() {
-				this.loadmore()
+				console.log('scrolltolower 外部到啦')
+				
+			},
+
+			scrolltoupper() {
+				console.log('scrolltoupper到scrolltoupper')
 			},
 			loadmore() {
 				for (let i = 0; i < 30; i++) {

--- a/src/uni_modules/uview-plus/components/u-list/u-list.vue
+++ b/src/uni_modules/uview-plus/components/u-list/u-list.vue
@@ -114,7 +114,7 @@
 			this.anchors = []
 		},
 		mounted() {},
-		emits: ["scroll", "scrolltolower", "scrolltoupper",
+		emits: ["scroll", "scroll-to-lower","scrolltolower", "scrolltoupper",
 			"refresherpulling", "refresherrefresh", "refresherrestore", "refresherabort"],
 		methods: {
 			updateOffsetFromChild(top) {
@@ -143,13 +143,18 @@
 			},
 			// 滚动到底部触发事件
 			scrolltolower(e) {
+				
+				
 				sleep(30).then(() => {
 					this.$emit('scrolltolower')
+					this.$emit('scroll-to-lower')
 				})
+	
 			},
 			// #ifndef APP-NVUE
 			// 滚动到底部时触发，非nvue有效
 			scrolltoupper(e) {
+		
 				sleep(30).then(() => {
 					this.$emit('scrolltoupper')
 					// 这一句很重要，能绝对保证在性功能障碍的webview，滚动条到顶时，取消偏移值，让页面置顶

--- a/src/uni_modules/uview-plus/components/u-list/u-list.vue
+++ b/src/uni_modules/uview-plus/components/u-list/u-list.vue
@@ -143,13 +143,10 @@
 			},
 			// 滚动到底部触发事件
 			scrolltolower(e) {
-				
-				
 				sleep(30).then(() => {
 					this.$emit('scrolltolower')
 					this.$emit('scroll-to-lower')
 				})
-	
 			},
 			// #ifndef APP-NVUE
 			// 滚动到底部时触发，非nvue有效


### PR DESCRIPTION
新增一个大小写方法scroll-to-lower在原有的基础上额外暴露触底方法
	<up-list

			@scroll-to-lower="scrollToLower"
			
		
		>
			<up-list-item
				v-for="(item, index) in indexList"
				:key="index"
			>
				<up-cell
					:title="`列表长度-${index + 1}`"
				>
					<template #icon>
						<up-avatar
							shape="square"
							size="35"
							:src="item.url"
							customStyle="margin: -3px 5px -3px 0"
						></up-avatar>
					</template>
				</up-cell>
			</up-list-item>
		</up-list>
支付宝小程序可以使用@scroll-to-lower="scrollToLower" 额外触发
✅ Closes: #422