### PR TITLE
解决在ios小程序中底部操作栏被遮挡的问题

### DIFF
--- a/src/uni_modules/uview-plus/components/u-cropper/u-cropper.vue
+++ b/src/uni_modules/uview-plus/components/u-cropper/u-cropper.vue
@@ -76,7 +76,8 @@
 				expHeight: '',
 				// 是否允许调整裁剪框大小
 				letChangeSize: false,
-				
+				// 底部安全区大小
+				safeAreaInsetsBottom: 0,
 			};
 		},
 		watch: {
@@ -151,6 +152,7 @@
 				this.platform = sysInfo.platform;
 				this.pixelRatio = sysInfo.pixelRatio;
 				this.windowWidth = sysInfo.windowWidth;
+				this.safeAreaInsetsBottom = sysInfo.safeAreaInsets.bottom;
 				// #ifdef H5
 				this.drawTop = sysInfo.windowTop;
 				this.windowHeight = sysInfo.windowHeight + sysInfo.windowBottom;
@@ -162,12 +164,12 @@
 					this.cvsStyleHeight = this.windowHeight - tabHeight + 'px';
 				} else {
 					this.windowHeight = sysInfo.windowHeight + this.moreHeight;
-					this.cvsStyleHeight = this.windowHeight - tabHeight + 6 + 'px';
+					this.cvsStyleHeight = this.windowHeight - tabHeight - this.safeAreaInsetsBottom + 6 + 'px';
 				}
 				// #endif
 				// #ifdef MP
 				this.windowHeight = sysInfo.windowHeight + this.moreHeight;
-				this.cvsStyleHeight = this.windowHeight - tabHeight - 2 + 'px';
+				this.cvsStyleHeight = this.windowHeight - tabHeight - this.safeAreaInsetsBottom - 2 + 'px';
 				// #endif
 				this.pxRatio = this.windowWidth/750;
 
@@ -1226,3 +1228,4 @@
 	}
 }
 </style>
+


### PR DESCRIPTION

![修改后](https://github.com/user-attachments/assets/5a529653-d442-40b8-88db-8257a744dfdc)
![修改前](https://github.com/user-attachments/assets/6305229c-39f6-46e6-b63e-88a479527802)
原因：canvas 属于原生组件，层级是最高的，不管你设置任何的z-index都是不能覆盖到这些原生组件上。 解决方法：在加载时获取底部安全区高度，在设置canvas标签高度时减去安全区高度，防止遮挡底部操作栏