### PR TITLE
improvment: 优化Cascader级联选择器右上角关闭图标的显示控制

### DIFF
--- a/src/uni_modules/uview-plus/components/u-cascader/u-cascader.vue
+++ b/src/uni_modules/uview-plus/components/u-cascader/u-cascader.vue
@@ -1,6 +1,6 @@
 <template>
 	<up-popup :show="popupShow" mode="bottom" :popup="false"
-		:mask="true" :closeable="true" :safe-area-inset-bottom="true"
+		:mask="true" :closeable="closeable" :safe-area-inset-bottom="true"
 		close-icon-color="#ffffff" :z-index="uZIndex"
 		:maskCloseAble="maskCloseAble" @close="close">
 		<view class="up-p-t-30 up-p-l-20 up-m-b-10" v-if="headerDirection =='column'">
@@ -61,6 +61,7 @@
 	 * @property {String} labelKey 指定选项标签为选项对象中的哪个属性值
 	 * @property {String} childrenKey 指定选项的子选项为选项对象中的哪个属性值
 	 * @property {Boolean} autoClose 是否在选择最后一级时自动关闭并触发confirm（默认false）
+	 * @property {Boolean} closeable 是否显示关闭图标（默认true）
 	 */
 	import { t } from '../../libs/i18n'
 	export default {
@@ -124,6 +125,11 @@
 			optionsCols: {
 				type: [Number],
 				default: 2
+			},
+			// 是否显示关闭图标
+			closeable: {
+				type: Boolean,
+				default: true
 			}
 		},
 		data() {


### PR DESCRIPTION
如果在级联文本过长或者类目过多时关闭图标会与类目文字重合，现在增加控制关闭图标的控制可以控制是否需要显示关闭图标，底部有取消按钮，关闭图标不是必须的