### PR TITLE
修复align-self属性值缺少d导致样式不生效的问题

### DIFF
--- a/src/uni_modules/uview-plus/libs/css/flex.scss
+++ b/src/uni_modules/uview-plus/libs/css/flex.scss
@@ -250,7 +250,7 @@
 // 子元素交叉轴终点对齐
 .u-flex-self-end,
 .up-flex-self-end {
-	align-self: flex-en !important;
+	align-self: flex-end !important;
 }
 
 // 子元素交叉轴第一行文字基线对齐
@@ -366,3 +366,4 @@
 		}
 	}
 }
+


### PR DESCRIPTION
.u-flex-self-end，
.up-flex-self-end这两个类名的样式由于flex-end少了d导致不生效