### PR TITLE
fix: 修复 popup 弹出层背景色修改后，在小程序端默认背景色还存在

### DIFF
--- a/src/uni_modules/uview-plus/components/u-popup/popup.js
+++ b/src/uni_modules/uview-plus/components/u-popup/popup.js
@@ -23,7 +23,7 @@ export default {
         closeIconPos: 'top-right',
         round: '20px',
         zoom: true,
-        bgColor: '',
+        bgColor: '#fff',
         overlayOpacity: 0.5,
         pageInline: false,
         touchable: false,

--- a/src/uni_modules/uview-plus/components/u-popup/u-popup.vue
+++ b/src/uni_modules/uview-plus/components/u-popup/u-popup.vue
@@ -196,9 +196,7 @@
 					style.flex = 1
 				}
 				// 背景色，一般用于设置为transparent，去除默认的白色背景
-				if (this.bgColor) {
-					style.backgroundColor = this.bgColor
-				}
+				style.backgroundColor = this.bgColor
 				if(this.round) {
 					const value = addUnit(this.round)
 					if(this.mode === 'top') {
@@ -344,7 +342,6 @@
 
 <style lang="scss" scoped>
 	$u-popup-flex:1 !default;
-	$u-popup-content-background-color: #fff !default;
 
 	.u-popup {
 		flex: $u-popup-flex;
@@ -361,7 +358,6 @@
 		}
 
 		&__content {
-			background-color: $u-popup-content-background-color;
 			position: relative;
 
 			&--round-top {


### PR DESCRIPTION
代码
<img width="602" height="110" alt="daffc598-f728-407c-bfb6-eab4263c245a" src="https://github.com/user-attachments/assets/d2d34bd1-6570-4dff-8fcd-73a33a98a3fc" />

### web端
中间
<img width="378" height="820" alt="image" src="https://github.com/user-attachments/assets/9b35691c-f567-4896-b0f2-de5665e959b2" />
其他位置
<img width="378" height="820" alt="image" src="https://github.com/user-attachments/assets/fbde802c-3b4a-4028-9ff5-937729128435" />



### 小程序端（旧）
中间
<img width="418" height="855" alt="image" src="https://github.com/user-attachments/assets/e053a1f2-3a3c-41f6-ad00-8df44181985e" />
其他位置
<img width="406" height="842" alt="image" src="https://github.com/user-attachments/assets/e5f9b3f2-e199-4513-b5fc-933faf166c0b" />


### 小程序端（新）
中间
<img width="428" height="852" alt="image" src="https://github.com/user-attachments/assets/3de4a07c-4f82-454d-849a-c08f60163409" />
其他位置
<img width="408" height="868" alt="image" src="https://github.com/user-attachments/assets/51fbe684-47d8-449a-b4d5-bb738bcabed7" />


