### PR TITLE
fix:issues 999 u-picker添加默认背景色 防止其他使用该组件的没有配置背景色导致奇怪的样式

### DIFF
--- a/src/uni_modules/uview-plus/components/u-picker/picker.js
+++ b/src/uni_modules/uview-plus/components/u-picker/picker.js
@@ -7,36 +7,37 @@
  * @lastTime     : 2025-12-19 08:55:21
  * @FilePath     : /uview-plus/libs/config/props/picker.js
  */
-import { t } from '../../libs/i18n'
+import { t } from '../../libs/i18n';
+
 export default {
     // picker
     picker: {
         show: false,
-		popupMode: 'bottom',
+        popupMode: 'bottom',
         showToolbar: true,
         title: '',
         columns: [],
         loading: false,
         itemHeight: 44,
-        cancelText: t("up.common.cancel"),
-        confirmText: t("up.common.confirm"),
+        cancelText: t('up.common.cancel'),
+        confirmText: t('up.common.confirm'),
         cancelColor: '#909193',
         confirmColor: '',
         visibleItemCount: 5,
         keyName: 'text',
-		valueName: 'value',
+        valueName: 'value',
         closeOnClickOverlay: false,
         defaultIndex: [],
-		immediateChange: true,
-		zIndex: 10076,
+        immediateChange: true,
+        zIndex: 10076,
         disabled: false,
         disabledColor: '',
-        placeholder: t("up.common.pleaseChoose"),
+        placeholder: t('up.common.pleaseChoose'),
         inputProps: {},
-        bgColor: '',
+        bgColor: '#FFFFFF',
         round: 0,
         duration: 300,
         overlayOpacity: 0.5,
         pageInline: false
     }
-}
+};


### PR DESCRIPTION
close: #999 
添加 u-picker 的默认背景色

补个图
<img width="468" height="916" alt="image" src="https://github.com/user-attachments/assets/adee7d74-0b08-4207-9041-da16b7d1d23d" />
