### PR TITLE
fix:issues 940 stepsItem.d.ts ts插槽name更新

### DIFF
--- a/src/uni_modules/uview-plus/types/comps/stepsItem.d.ts
+++ b/src/uni_modules/uview-plus/types/comps/stepsItem.d.ts
@@ -23,10 +23,14 @@ declare interface StepsItemProps {
 }
 
 declare interface StepsItemSlots {
-  /**
-   * 自定步骤状态内容
-   */
-  ['default']?: () => any
+  // 自定步骤整体内容
+  ['content']?: () => any,
+  // 自定步骤图标
+  ['icon']?: () => any,
+  // 自定步骤标题
+  ['title']?: () => any,
+  // 自定步骤描述
+  ['desc']?: () => any,
 }
 
 declare interface _StepsItem {


### PR DESCRIPTION
close: #940

ts校验可以通过
<img width="822" height="637" alt="image" src="https://github.com/user-attachments/assets/69e77f96-fa6e-4023-b541-36b7557ddb9e" />

另外文档上我看有默认插槽但是我在源码中没有找到，作者看下是否要同步给更新下文档

文档截图
<img width="1816" height="1031" alt="image" src="https://github.com/user-attachments/assets/9e422b89-4849-4b4e-8837-d8af1e7db277" />

源码截图
<img width="1425" height="702" alt="image" src="https://github.com/user-attachments/assets/4eaa3007-bba0-4183-8226-9abaebb20fbb" />
