### PR TITLE
fix(tooltip): 修复tooltip组件字体大小(size)属性未生效的问题

### DIFF
--- a/src/uni_modules/uview-plus/components/u-tooltip/u-tooltip.vue
+++ b/src/uni_modules/uview-plus/components/u-tooltip/u-tooltip.vue
@@ -19,6 +19,7 @@
 					:selectable="false"
 					:style="{
 						color: color,
+						fontSize: $u.addUnit(size),
 						backgroundColor: bgColor && showTooltip && tooltipTop !== -10000 ? bgColor : 'transparent'
 					}"
 				>{{ text }}</text>


### PR DESCRIPTION
tooltip 组件的 size 属性，目前没有生效，无法在页面控制<text>标签中文字的大小。
text标签的 style 添加 $u.addUnit(size) 。