### PR TITLE
fix(picker): 修复异步columns加载时defaultIndex位置不更新问题 (#841)

### DIFF
--- a/src/uni_modules/uview-plus/components/u-picker/u-picker.vue
+++ b/src/uni_modules/uview-plus/components/u-picker/u-picker.vue
@@ -407,10 +407,25 @@ export default {
 		// 设置整体各列的columns的值
 		setColumns(columns) {
 			// console.log(columns)
+			const prevColumns = this.innerColumns
 			this.innerColumns = deepClone(columns)
 			// 如果在设置各列数据时，没有被设置默认的各列索引defaultIndex，那么用0去填充它，数组长度为列的数量
 			if (this.innerIndex.length === 0) {
 				this.innerIndex = new Array(columns.length).fill(0)
+			} else {
+				// 修复异步columns加载时defaultIndex位置不更新的问题 (issue #841)
+				// 当某列从空数组变为有数据时，picker-view不会因为:value未变化而重新滚动到指定位置
+				// 需要通过先清空再赋值的方式强制触发picker-view的滚动更新
+				const hasColumnsChangedFromEmpty = columns.some(
+					(col, i) => col && col.length > 0 && (!prevColumns[i] || prevColumns[i].length === 0)
+				)
+				if (hasColumnsChangedFromEmpty) {
+					const targetIndex = deepClone(this.innerIndex)
+					this.innerIndex = []
+					this.$nextTick(() => {
+						this.innerIndex = targetIndex
+					})
+				}
 			}
 		},
 		// 获取各列选中值对应的索引


### PR DESCRIPTION
## 问题描述

当 `columns` 是接口动态返回时（如初始为空数组 `[[], []]`，延迟后赋值为有数据的数组），`defaultIndex` 设置的位置不会正确更新，picker 仍停留在第 0 项而不是指定的位置。

关联 Issue: #841

## 根本原因

执行顺序如下：
1. 组件初始化，`defaultIndex` watcher 触发，设置 `innerIndex = [2, 0]`
2. `columns` watcher 触发（初始空数组），`setColumns` 执行，因 `innerIndex.length !== 0` 不做处理
3. 2秒后 `columns` 异步赋值为有数据的数组，`setColumns` 再次执行
4. **此时 `innerIndex` 仍为 `[2, 0]`，值未发生变化，`picker-view` 的 `:value` 绑定不触发重新渲染，导致滚动位置停留在 0**

## 修复方案

在 `setColumns` 中检测是否有列从空变为有数据。若是，则先将 `innerIndex` 清空，再在 `$nextTick` 中恢复目标值，强制触发 `picker-view` 的滚动更新。

## 测试场景

- 修复前：`defaultIndex = [2, 0]` + 异步 columns → picker 显示在第 0 项（错误）
- 修复后：`defaultIndex = [2, 0]` + 异步 columns → picker 正确滚动到第 3 项

🤖 Generated with [Claude Code](https://claude.com/claude-code)