### PR TITLE
fix(u-color-picker): 增加box-sizing解决content padding撑开宽度问题

### DIFF
--- a/src/uni_modules/uview-plus/components/u-color-picker/u-color-picker.vue
+++ b/src/uni_modules/uview-plus/components/u-color-picker/u-color-picker.vue
@@ -801,6 +801,7 @@ export default {
 		width: 100%;
 		padding: 20px;
 		background-color: var(--up-card-bg-color, #fff);
+		box-sizing: border-box;
 	}
 	
 	&__header {


### PR DESCRIPTION
u-color-picker 内部 &__content 设置 padding: 20px，未设置 box-sizing: border-box，padding 向外扩展导致容器横向溢出、页面被撑开。
给 &__content 样式增加 box-sizing: border-box;，内边距向内计算，保证宽度始终为 100% 不溢出。
<img width="390" height="844" alt="1fa9a3ee-9e4a-4483-bcfa-d7ba8cd354a9" src="https://github.com/user-attachments/assets/06e22a26-a973-4eb6-bcab-69f2b5fcd49d" />
![Uploading 06e2e7eb-cd3a-4bd7-a7d6-a157ed2be4e4.png…]()
