### PR TITLE
u-calendar面板选择的日期始终比实际日期小一天。用户时区为GMT-11:00时。

### DIFF
--- a/src/uni_modules/uview-plus/components/u-calendar/u-calendar.vue
+++ b/src/uni_modules/uview-plus/components/u-calendar/u-calendar.vue
@@ -643,7 +643,7 @@ export default {
 										dayjs(maxDate).format('YYYY-MM-DD')
 									),
 								// 返回一个日期对象，供外部的formatter获取当前日期的年月日等信息，进行加工处理
-								date: new Date(date),
+								date: dayjs(date).$d,
 								bottomInfo,
 								dot: false,
 								month:


### PR DESCRIPTION
<img width="1522" height="704" alt="img_v3_02135_a6de2565-ba06-4715-897b-520eb601a34m" src="https://github.com/user-attachments/assets/f2fd708d-aafd-429e-a222-ab790f8fa5a2" />
<img width="864" height="410" alt="image" src="https://github.com/user-attachments/assets/4e407236-6f3e-4a15-af04-9ef5bfcc60bf" />
如图片所示，当前电脑时区为GMT-11:00时，2026-06-30，通过new Date转换成29号了，修改成dayjs的方式转换就没有此问题了。