### PR TITLE
修复微信小程序组件兼容性

### DIFF
--- a/src/uni_modules/uview-plus/components/u-cascader/u-cascader.vue
+++ b/src/uni_modules/uview-plus/components/u-cascader/u-cascader.vue
@@ -348,7 +348,7 @@
 		overflow: hidden;
 		height: 800rpx;
 
-		>view {
+		>.u-flex {
 			width: 150%;
 			transition: transform 0.3s ease-in-out 0s;
 			transform: translateX(0);

--- a/src/uni_modules/uview-plus/components/u-cropper/u-cropper.vue
+++ b/src/uni_modules/uview-plus/components/u-cropper/u-cropper.vue
@@ -7,25 +7,25 @@
 		<view class="oper-wrapper" :style="{ display: styleDisplay }">
 			<view class="oper">
 				<view class="btn-wrapper" v-if="showOper">
-					<view @click="select" hover-class="hover" :style="{ width: btnWidth }">
+					<view class="u-cropper__action" @click="select" hover-class="hover" :style="{ width: btnWidth }">
 						<text>{{ t("up.common.re-select") }}</text>
 					</view>
-					<view @click="close" hover-class="hover" :style="{ width: btnWidth }">
+					<view class="u-cropper__action" @click="close" hover-class="hover" :style="{ width: btnWidth }">
 						<text>{{ t("up.common.close") }}</text>
 					</view>
-					<view @click="rotate" hover-class="hover" :style="{ width: btnWidth, display: btnDsp }">
+					<view class="u-cropper__action" @click="rotate" hover-class="hover" :style="{ width: btnWidth, display: btnDsp }">
 						<text>{{ t("up.common.rotate") }}</text>
 					</view>
-					<view @click="preview" hover-class="hover" :style="{ width: btnWidth }">
+					<view class="u-cropper__action" @click="preview" hover-class="hover" :style="{ width: btnWidth }">
 						<text>{{ t("up.common.preview") }}</text>
 					</view>
-					<view @click="confirm" hover-class="hover" :style="{ width: btnWidth }">
+					<view class="u-cropper__action" @click="confirm" hover-class="hover" :style="{ width: btnWidth }">
 						<text>{{ t("up.common.confirm") }}</text>
 					</view>
 				</view>
 				<view class="clr-wrapper" v-else>
 					<slider class="my-slider" @change="colorChange" block-size="25" value="0" min="-100" max="100" activeColor="red" backgroundColor="green" block-color="grey" show-value></slider>
-					<view @click="prvUpload" hover-class="hover" :style="{ width: btnWidth }">
+					<view class="u-cropper__action" @click="prvUpload" hover-class="hover" :style="{ width: btnWidth }">
 						<text>{{ t("up.common.confirm") }}</text>
 					</view>
 				</view>
@@ -1267,7 +1267,7 @@
 			justify-content: space-between;
 		}
 
-		.btn-wrapper view {
+		.btn-wrapper .u-cropper__action {
 			display: flex;
 			align-items: center;
 			justify-content: center;
@@ -1288,7 +1288,7 @@
 			flex-grow: 1;
 		}
 
-		.clr-wrapper view {
+		.clr-wrapper .u-cropper__action {
 			display: flex;
 			align-items: center;
 			justify-content: center;

--- a/src/uni_modules/uview-plus/components/u-float-button/u-float-button.vue
+++ b/src/uni_modules/uview-plus/components/u-float-button/u-float-button.vue
@@ -159,7 +159,7 @@ export default {
         bottom: 0px;
         display: flex;
         flex-direction: column;
-        >view {
+        >.u-float-button__item {
             margin: 5px 0px;
         }
     }

--- a/src/uni_modules/uview-plus/components/u-goods-sku/u-goods-sku.vue
+++ b/src/uni_modules/uview-plus/components/u-goods-sku/u-goods-sku.vue
@@ -16,7 +16,7 @@
                 <view class="up-goods-sku__header">
                     <slot name="header">
                         <view class="up-goods-sku__header__image">
-                            <image :src="goodsInfo.image || goodsInfo.picture" mode="aspectFill"></image>
+                            <image class="up-goods-sku__header__image-element" :src="goodsInfo.image || goodsInfo.picture" mode="aspectFill"></image>
                         </view>
                         <view class="up-goods-sku__header__info">
                             <view class="up-goods-sku__header__info__price">
@@ -333,7 +333,7 @@
 				overflow: hidden;
 				margin-right: 20rpx;
 				
-				image {
+				&-element {
 					width: 100%;
 					height: 100%;
 				}

--- a/src/uni_modules/uview-plus/components/u-navbar/theme-vars.scss
+++ b/src/uni_modules/uview-plus/components/u-navbar/theme-vars.scss
@@ -1,3 +1,16 @@
+/* #ifdef MP-WEIXIN */
+:host {
+	--up-navbar-bg-color: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+	:host {
+		--up-navbar-bg-color: #1c1c1e;
+	}
+}
+/* #endif */
+
+/* #ifndef MP-WEIXIN */
 :root,
 page,
 body {
@@ -24,3 +37,4 @@ body {
 	--up-navbar-bg-color: #1c1c1e;
 	--up-navbar-glass-bg-color: rgba(28, 28, 30, 0.82);
 }
+/* #endif */

--- a/src/uni_modules/uview-plus/components/u-notice-bar/theme-vars.scss
+++ b/src/uni_modules/uview-plus/components/u-notice-bar/theme-vars.scss
@@ -1,3 +1,18 @@
+/* #ifdef MP-WEIXIN */
+:host {
+	--up-notice-bar-color: #f9ae3d;
+	--up-notice-bar-bg-color: #fdf6ec;
+}
+
+@media (prefers-color-scheme: dark) {
+	:host {
+		--up-notice-bar-color: #f9ae3d;
+		--up-notice-bar-bg-color: #3d2f1b;
+	}
+}
+/* #endif */
+
+/* #ifndef MP-WEIXIN */
 :root,
 page,
 body {
@@ -23,3 +38,4 @@ body {
 	--up-notice-bar-color: #f9ae3d;
 	--up-notice-bar-bg-color: #3d2f1b;
 }
+/* #endif */

--- a/src/uni_modules/uview-plus/components/u-parse/node/node.vue
+++ b/src/uni_modules/uview-plus/components/u-parse/node/node.vue
@@ -53,14 +53,14 @@
       <!-- #endif -->
       <view v-else-if="(n.name==='table'&&n.c)||n.name==='li'" :id="n.attrs.id" :class="'_'+n.name+' '+n.attrs.class" :style="n.attrs.style">
         <node v-if="n.name==='li'" :childs="n.children" :opts="opts" />
-        <view v-else v-for="(tbody, x) in n.children" v-bind:key="x" :class="'_'+tbody.name+' '+tbody.attrs.class" :style="tbody.attrs.style">
+        <view v-else v-for="(tbody, x) in (n && n.children || [])" v-bind:key="x" :class="'_'+tbody.name+' '+tbody.attrs.class" :style="tbody.attrs.style">
           <node v-if="tbody.name==='td'||tbody.name==='th'" :childs="tbody.children" :opts="opts" />
-          <block v-else v-for="(tr, y) in tbody.children" v-bind:key="y">
+          <block v-else v-for="(tr, y) in (tbody && tbody.children || [])" v-bind:key="y">
             <view v-if="tr.name==='td'||tr.name==='th'" :class="'_'+tr.name+' '+tr.attrs.class" :style="tr.attrs.style">
               <node :childs="tr.children" :opts="opts" />
             </view>
             <view v-else :class="'_'+tr.name+' '+tr.attrs.class" :style="tr.attrs.style">
-              <view v-for="(td, z) in tr.children" v-bind:key="z" :class="'_'+td.name+' '+td.attrs.class" :style="td.attrs.style">
+              <view v-for="(td, z) in (tr && tr.children || [])" v-bind:key="z" :class="'_'+td.name+' '+td.attrs.class" :style="td.attrs.style">
                 <node :childs="td.children" :opts="opts" />
               </view>
             </view>
@@ -70,7 +70,7 @@
       <!-- insert -->
       <!-- 富文本 -->
       <!-- #ifdef H5 || ((MP-WEIXIN || MP-QQ || APP-PLUS || MP-360) && VUE2) -->
-      <rich-text v-else-if="!n.c&&!handler.isInline(n.name, n.attrs.style)" :id="n.attrs.id" :style="n.f" :user-select="opts[4]" :nodes="[n]" />
+      <rich-text v-else-if="!n.c&&!isInlineTag(n.name, n.attrs.style)" :id="n.attrs.id" :style="n.f" :user-select="opts[4]" :nodes="[n]" />
       <!-- #endif -->
       <!-- #ifndef H5 || ((MP-WEIXIN || MP-QQ || APP-PLUS || MP-360) && VUE2) -->
       <rich-text v-else-if="!n.c" :id="n.attrs.id" :style="'display:inline;'+n.f" :preview="false" :selectable="opts[4]" :user-select="opts[4]" :nodes="[n]" />
@@ -185,6 +185,25 @@ export default {
     // #ifdef MP-WEIXIN
     toJSON () { return this },
     // #endif
+    isInlineTag (tagName, style) {
+      return {
+        abbr: true,
+        b: true,
+        big: true,
+        code: true,
+        del: true,
+        em: true,
+        i: true,
+        ins: true,
+        label: true,
+        q: true,
+        small: true,
+        span: true,
+        strong: true,
+        sub: true,
+        sup: true
+      }[tagName] || (style || '').indexOf('display:inline') !== -1
+    },
     /**
      * @description 规范化链接地址
      * @param {any} href

--- a/src/uni_modules/uview-plus/components/u-subsection/theme-vars.scss
+++ b/src/uni_modules/uview-plus/components/u-subsection/theme-vars.scss
@@ -1,3 +1,26 @@
+/* #ifdef MP-WEIXIN */
+:host {
+	--up-subsection-bg-color: #eeeeef;
+	--up-subsection-bar-color: #ffffff;
+	--up-subsection-inactive-color: #303133;
+	--up-subsection-disabled-text-color: #c8c9cc;
+	--up-subsection-disabled-border-color: #d4d4d4;
+	--up-subsection-disabled-bar-color: #f5f5f5;
+}
+
+@media (prefers-color-scheme: dark) {
+	:host {
+		--up-subsection-bg-color: #2b2c30;
+		--up-subsection-bar-color: #3a3b40;
+		--up-subsection-inactive-color: #d1d5db;
+		--up-subsection-disabled-text-color: #6b7280;
+		--up-subsection-disabled-border-color: #3a3a3c;
+		--up-subsection-disabled-bar-color: #3a3a3c;
+	}
+}
+/* #endif */
+
+/* #ifndef MP-WEIXIN */
 :root,
 page,
 body {
@@ -39,3 +62,4 @@ body {
 	--up-subsection-disabled-border-color: #3a3a3c;
 	--up-subsection-disabled-bar-color: #3a3a3c;
 }
+/* #endif */

--- a/src/uni_modules/uview-plus/components/u-switch/theme-vars.scss
+++ b/src/uni_modules/uview-plus/components/u-switch/theme-vars.scss
@@ -1,3 +1,26 @@
+/* #ifdef MP-WEIXIN */
+:host {
+	--up-switch-active-color: #3c9cff;
+	--up-switch-inactive-color: #ffffff;
+	--up-switch-dot-active-color: #ffffff;
+	--up-switch-dot-inactive-color: #ffffff;
+	--up-switch-loading-inactive-color: #aaabad;
+	--up-switch-border-color: rgba(0, 0, 0, 0.12);
+}
+
+@media (prefers-color-scheme: dark) {
+	:host {
+		--up-switch-active-color: #3c9cff;
+		--up-switch-inactive-color: #3a3a3c;
+		--up-switch-dot-active-color: #ffffff;
+		--up-switch-dot-inactive-color: #d1d5db;
+		--up-switch-loading-inactive-color: #9ca3af;
+		--up-switch-border-color: #4b5563;
+	}
+}
+/* #endif */
+
+/* #ifndef MP-WEIXIN */
 :root,
 page,
 body {
@@ -39,3 +62,4 @@ body {
 	--up-switch-loading-inactive-color: #9ca3af;
 	--up-switch-border-color: #4b5563;
 }
+/* #endif */

--- a/src/uni_modules/uview-plus/components/u-tag/theme-vars.scss
+++ b/src/uni_modules/uview-plus/components/u-tag/theme-vars.scss
@@ -1,3 +1,16 @@
+/* #ifdef MP-WEIXIN */
+:host {
+	--up-tag-close-bg-color: #c8c9cc;
+}
+
+@media (prefers-color-scheme: dark) {
+	:host {
+		--up-tag-close-bg-color: #4b5563;
+	}
+}
+/* #endif */
+
+/* #ifndef MP-WEIXIN */
 :root,
 page,
 body {
@@ -19,3 +32,4 @@ body {
 [data-up-theme='dark'] {
 	--up-tag-close-bg-color: #4b5563;
 }
+/* #endif */


### PR DESCRIPTION
## 背景

在微信小程序组件作用域和 uni-app SFC 转换场景下，当前组件源码会触发 selector 告警、主题变量不生效，以及 `u-parse` 节点处理异常。相关问题与 #1018 的微信 selector 告警一致。

## 改动

- 收窄 `u-cascader`、`u-float-button`、`u-cropper`、`u-goods-sku` 的宽泛选择器，避免误匹配原生组件。
- 为 `u-navbar`、`u-notice-bar`、`u-subsection`、`u-switch`、`u-tag` 补充 `MP-WEIXIN` 下的 `:host` 主题变量，同时保留 Web 端变量输出。
- 为 `u-parse/node` 的表格 children 增加空值兜底，并在小程序路径使用本地行内标签判断，避免依赖 WXS handler。

## 验证

已运行：

- `node scripts/verify-navbar-theme-runtime.mjs`
- `node scripts/verify-navbar-ios-mode.mjs`
- `node scripts/verify-cropper-inner.mjs`
- `node scripts/verify-cropper-image-src.mjs`
- `node scripts/verify-up-canvas-unification.mjs`
- `node scripts/verify-up-create-intersection-observer.mjs`

上述检查均通过。